### PR TITLE
Refactor: simplify columns_cleanups using regexs

### DIFF
--- a/core/cleaner.py
+++ b/core/cleaner.py
@@ -29,14 +29,15 @@ class SheetCleaner:
 
         # only keep letters (default) or replace a given list of characters
         if not characters_to_replace:
-            regex_expression = "[^a-zA-Z]+"
+            regex_expression = "[^a-zA-Z0-9]+"
         else:
             if len(characters_to_replace) > 1:
                 regex_expression = r"[" + "\\" + "\\".join(characters_to_replace) + "]+"
             else:
                 regex_expression = r"[" + "\\" + characters_to_replace[0] + "]+"
 
-        # replace specified characters with the default_replacement and remove consecutive and trailing whitespace and default_replacement
+        # replace specified characters with the default_replacement and remove consecutive and
+        # trailing whitespace and default_replacement
         df.columns = [
             re.sub(regex_expression, default_replacement, col).strip(default_replacement).strip()
             for col in df.columns

--- a/core/cleaner.py
+++ b/core/cleaner.py
@@ -23,22 +23,38 @@ class SheetCleaner:
         return clean_df
 
     @staticmethod
-    def columns_cleanups(df):
+    def columns_cleanups(
+        df,
+        characters_to_replace=[
+            "*",
+            "/",
+            ".",
+            "?",
+            "_",
+            "%",
+            "s",
+            "\\",
+            "#",
+            "&",
+            "$",
+            "|",
+            "<",
+            ">",
+            "=",
+            "+",
+            "-",
+            "'",
+            '"',
+        ],
+        default_replacement="_",
+    ):
 
-        # clean column names (slashes and spaces to understore), remove trailing whitespace
-        df.columns = [re.sub(r"^\d+", "", col) for col in df.columns]
+        # clean column names by replacing characters_to_replace with default_replacement, remove trailing whitespace and consecutive default_replacement
+        regex_expression = r"[" + "\\".join(characters_to_replace) + "]+"
         df.columns = [
-            col.replace(" ", "_")
-            .replace("/", "_")
-            .replace(".", "_")
-            .replace("?", "_")
-            .replace("__", "_")
-            .strip()
+            re.sub(regex_expression, default_replacement, col).strip().strip(default_replacement)
             for col in df.columns
         ]
-        df.columns = [re.sub(r"^\_+", "", col) for col in df.columns]
-        df.columns = [re.sub(r"\_+$", "", col) for col in df.columns]
-        df.columns = [re.sub(r"[^\w\s]", "", col) for col in df.columns]
 
         # remove empty cols
         if "" in df.columns:

--- a/core/cleaner.py
+++ b/core/cleaner.py
@@ -23,34 +23,15 @@ class SheetCleaner:
         return clean_df
 
     @staticmethod
-    def columns_cleanups(
-        df,
-        characters_to_replace=[
-            "*",
-            "/",
-            ".",
-            "?",
-            "_",
-            "%",
-            "s",
-            "\\",
-            "#",
-            "&",
-            "$",
-            "|",
-            "<",
-            ">",
-            "=",
-            "+",
-            "-",
-            "'",
-            '"',
-        ],
-        default_replacement="_",
-    ):
+    def columns_cleanups(df, default_replacement="_", characters_to_replace=None):
 
-        # clean column names by replacing characters_to_replace with default_replacement, remove trailing whitespace and consecutive default_replacement
-        regex_expression = r"[" + "\\".join(characters_to_replace) + "]+"
+        # only keep letters (default) or replace a given list of characters
+        if not characters_to_replace:
+            regex_expression = "[^a-zA-Z]+"
+        else:
+            regex_expression = r"[" + "\\".join(characters_to_replace) + "]+"
+
+        # replace specified characters with the default_replacement and remove consecutive and trailing whitespace and default_replacement
         df.columns = [
             re.sub(regex_expression, default_replacement, col).strip().strip(default_replacement)
             for col in df.columns

--- a/core/cleaner.py
+++ b/core/cleaner.py
@@ -23,17 +23,22 @@ class SheetCleaner:
         return clean_df
 
     @staticmethod
-    def columns_cleanups(df, default_replacement="_", characters_to_replace=None):
+    def columns_cleanups(
+        df: pandas.DataFrame, default_replacement: str = "_", characters_to_replace: list = None
+    ):
 
         # only keep letters (default) or replace a given list of characters
         if not characters_to_replace:
             regex_expression = "[^a-zA-Z]+"
         else:
-            regex_expression = r"[" + "\\".join(characters_to_replace) + "]+"
+            if len(characters_to_replace) > 1:
+                regex_expression = r"[" + "\\" + "\\".join(characters_to_replace) + "]+"
+            else:
+                regex_expression = r"[" + "\\" + characters_to_replace[0] + "]+"
 
         # replace specified characters with the default_replacement and remove consecutive and trailing whitespace and default_replacement
         df.columns = [
-            re.sub(regex_expression, default_replacement, col).strip().strip(default_replacement)
+            re.sub(regex_expression, default_replacement, col).strip(default_replacement).strip()
             for col in df.columns
         ]
 

--- a/core/cleaner.py
+++ b/core/cleaner.py
@@ -2,6 +2,7 @@ import re
 
 import inflection
 import pandas
+from typing import List, Union
 
 
 class SheetCleaner:
@@ -24,22 +25,30 @@ class SheetCleaner:
 
     @staticmethod
     def columns_cleanups(
-        df: pandas.DataFrame, default_replacement: str = "_", characters_to_replace: list = None
+        df: pandas.DataFrame,
+        default_replacement: str = "_",
+        characters_to_replace: Union[List[str], str] = list(),
     ):
+        # when provided, ensure characters_to_replace is a list
+        if isinstance(characters_to_replace, str):
+            characters_to_replace = [characters_to_replace]
 
-        # only keep letters (default) or replace a given list of characters
-        if not characters_to_replace:
-            regex_expression = "[^a-zA-Z0-9]+"
-        else:
+        # only keep alphanumeric by default
+        regex_string = "[^a-zA-Z0-9]+"
+
+        # or, replace a given list of characters when specified
+        if characters_to_replace:
+            escaped_slash = "\\"
             if len(characters_to_replace) > 1:
-                regex_expression = r"[" + "\\" + "\\".join(characters_to_replace) + "]+"
+                characters_to_replace = escaped_slash.join(characters_to_replace)
             else:
-                regex_expression = r"[" + "\\" + characters_to_replace[0] + "]+"
+                characters_to_replace = characters_to_replace[0]
+            regex_string = r"[{0}{1}]+".format(escaped_slash, characters_to_replace)
 
         # replace specified characters with the default_replacement and remove consecutive and
         # trailing whitespace and default_replacement
         df.columns = [
-            re.sub(regex_expression, default_replacement, col).strip(default_replacement).strip()
+            re.sub(regex_string, default_replacement, col).strip(default_replacement).strip()
             for col in df.columns
         ]
 

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -77,7 +77,7 @@ CAMEL_CASED_COLS = ["CamelCasedCol", "SnakeCasedCol"]
 CLEAN_DF = {
     "col_a": {0: 1, 1: 2, 2: 32},
     "col_b": {0: "as .", 1: "b", 2: "c"},
-    "col_one": {0: "aa", 1: "bb", 2: "cc"},
+    "1_col_one": {0: "aa", 1: "bb", 2: "cc"},
     "col_1": {0: 1, 1: 2, 2: 33},
     "long_ass_name": {0: "foo", 1: "bar", 2: "fizz"},
 }
@@ -85,7 +85,7 @@ CLEAN_DF = {
 RENAMED_DF = {
     "col_a": {0: 1, 1: 2, 2: 32},
     "col_b": {0: "as .", 1: "b", 2: "c"},
-    "col_one": {0: "aa", 1: "bb", 2: "cc"},
+    "1_col_one": {0: "aa", 1: "bb", 2: "cc"},
     "col_1": {0: 1, 1: 2, 2: 33},
     "renamed_col": {0: "foo", 1: "bar", 2: "fizz"},
 }


### PR DESCRIPTION
## Description

This PR is intended to simplify the cleanup of column names by generating a regular expression based on 2 variables:
- a list of all the characters to replace. By default, only letters will be kept
- the character to replace with. By default `_`

Note that this PR paves the way for introducing custom cleanup parameters. So next step is to parse new configurations

## How has this change been tested?
on ipython with a dummy df

## Checklist
- [x] The PR is named correctly according CONTRIBUTE.md standards.
- [x] My code follows the style guidelines (black formatting, typing etc.)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have tested that my code works
- [x] In case of breaking changes, I have provided enough notice or refactored code using the feature I have just changed
