### PR TITLE
feat(adaptor): :factory_worker: Implement Adapter Design

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r pip-requirements.txt -r dev-pip-requirements.txt
+          pip install --use-feature=2020-resolver -r pip-requirements.txt -r dev-pip-requirements.txt
       - name: Mypy checks
         uses: jpetrucciani/mypy-check@master
         with:

--- a/core/adapters/base/connection.py
+++ b/core/adapters/base/connection.py
@@ -1,7 +1,7 @@
 import abc
 
 
-class BaseCredentials(metaclass=abc.ABCMeta):
+class BaseCredentials(abc.ABC):
     """Base class to define basic API contract for a Credentials class and its methods."""
 
     @abc.abstractmethod
@@ -13,7 +13,7 @@ class BaseCredentials(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
 
-class BaseConnection(metaclass=abc.ABCMeta):
+class BaseConnection(abc.ABC):
     @abc.abstractmethod
     def generate_engine(self) -> None:
         raise NotImplementedError()

--- a/core/adapters/base/connection.py
+++ b/core/adapters/base/connection.py
@@ -1,0 +1,20 @@
+import abc
+
+
+class BaseCredentials(metaclass=abc.ABCMeta):
+    # TODO: Need to firgure out how to impose properties to be set
+    # and provided by the init
+
+    @abc.abstractmethod
+    def validate_credentials(self):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def parse_credentials(self):
+        raise NotImplementedError()
+
+
+class BaseConnection(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def generate_engine(self):
+        raise NotImplementedError()

--- a/core/adapters/base/connection.py
+++ b/core/adapters/base/connection.py
@@ -2,19 +2,18 @@ import abc
 
 
 class BaseCredentials(metaclass=abc.ABCMeta):
-    # TODO: Need to firgure out how to impose properties to be set
-    # and provided by the init
+    """Base class to define basic API contract for a Credentials class and its methods."""
 
     @abc.abstractmethod
-    def validate_credentials(self):
+    def validate_credentials(self) -> None:
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def parse_credentials(self):
+    def parse_credentials(self) -> None:
         raise NotImplementedError()
 
 
 class BaseConnection(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def generate_engine(self):
+    def generate_engine(self) -> None:
         raise NotImplementedError()

--- a/core/adapters/base/impl.py
+++ b/core/adapters/base/impl.py
@@ -1,38 +1,39 @@
 import abc
+from typing import Any, Dict, Optional
 
+import pandas
 from sqlalchemy.types import BOOLEAN, DATE, INTEGER, TIMESTAMP, VARCHAR, Numeric
 
 
 class BaseAdapter(metaclass=abc.ABCMeta):
-    """sets up required adapter methods
-    """
+    """sets up required adapter methods"""
 
     @abc.abstractmethod
-    def acquire_connection(self):
+    def acquire_connection(self) -> None:
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def close_connection(self):
+    def close_connection(self) -> None:
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def upload(self):
+    def upload(self, df: pandas.DataFrame, override_schema: str = str()) -> None:
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def excecute(self):
+    def excecute_query(self, query: str, return_results: bool = False) -> Optional[Any]:
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def check_table(self):
+    def check_table(self, target_schema: str, target_table: str) -> None:
         raise NotImplementedError()
 
     @staticmethod
-    def sqlalchemy_dtypes(dtypes_dict) -> dict:
+    def sqlalchemy_dtypes(dtypes_dict: Dict[str, Any]) -> Dict[str, Any]:
         dtypes_dict = dtypes_dict.copy()
-        dtypes_map = dict(
-            varchar=VARCHAR,
+        dtypes_map: Dict[str, Any] = dict(
             int=INTEGER,
+            varchar=VARCHAR,
             numeric=Numeric(38, 18),
             boolean=BOOLEAN,
             timestamp_ntz=TIMESTAMP,

--- a/core/adapters/base/impl.py
+++ b/core/adapters/base/impl.py
@@ -5,7 +5,7 @@ import pandas
 from sqlalchemy.types import BOOLEAN, DATE, INTEGER, TIMESTAMP, VARCHAR, Numeric
 
 
-class BaseAdapter(metaclass=abc.ABCMeta):
+class BaseSQLAdapter(abc.ABC):
     """sets up required adapter methods"""
 
     @abc.abstractmethod

--- a/core/adapters/base/impl.py
+++ b/core/adapters/base/impl.py
@@ -1,0 +1,26 @@
+import abc
+
+
+class BaseAdapter(metaclass=abc.ABCMeta):
+    """sets up required adapter methods
+    """
+
+    @abc.abstractmethod
+    def acquire_connection(self):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def close_connection(self):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def upload(self):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def excecute(self):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def check_table(self):
+        raise NotImplementedError()

--- a/core/adapters/base/impl.py
+++ b/core/adapters/base/impl.py
@@ -1,5 +1,7 @@
 import abc
 
+from sqlalchemy.types import BOOLEAN, DATE, INTEGER, TIMESTAMP, VARCHAR, Numeric
+
 
 class BaseAdapter(metaclass=abc.ABCMeta):
     """sets up required adapter methods
@@ -24,3 +26,19 @@ class BaseAdapter(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def check_table(self):
         raise NotImplementedError()
+
+    @staticmethod
+    def sqlalchemy_dtypes(dtypes_dict) -> dict:
+        dtypes_dict = dtypes_dict.copy()
+        dtypes_map = dict(
+            varchar=VARCHAR,
+            int=INTEGER,
+            numeric=Numeric(38, 18),
+            boolean=BOOLEAN,
+            timestamp_ntz=TIMESTAMP,
+            date=DATE,
+        )
+
+        for col, data_type in dtypes_dict.items():
+            dtypes_dict.update({col: dtypes_map[data_type]})
+        return dtypes_dict

--- a/core/adapters/connection.py
+++ b/core/adapters/connection.py
@@ -2,11 +2,13 @@ from typing import Dict
 
 from snowflake.sqlalchemy import URL
 from sqlalchemy import create_engine
+
+from core.adapters.base.connection import BaseConnection, BaseCredentials
 from core.config.profile import Profile
 from core.exceptions import CredentialsParsingError
 
 
-class Credentials:
+class SnowflakeCredentials(BaseCredentials):
     """This should be a base class down the line but for now it's kinda adhoc until all works fine."""
 
     def __init__(self, profile: Profile):
@@ -54,12 +56,12 @@ class Credentials:
                 self.credentials.update({key: self.profile.get(key, str())})
 
 
-class Connection:
+class SnowflakeConnection(BaseConnection):
     """For now this is also pretty adhocy until all works well and we can genericise into proper
     adaptor design.
     """
 
-    def __init__(self, credentials: Credentials):
+    def __init__(self, credentials: SnowflakeCredentials):
         self.db_type = credentials.db_type
         self.credentials = credentials
         self.generate_engine()

--- a/core/adapters/factory.py
+++ b/core/adapters/factory.py
@@ -1,10 +1,43 @@
-from typing import Dict, Type
-from core.adapters.base.impl import BaseAdapter
+import importlib
+from types import ModuleType
+from typing import Dict
 
-Adapter = BaseAdapter
+from core.config.profile import Profile
+
+# specify some more helpful types
+Adapter = ModuleType
 
 
 class AdapterContainer:
     def __init__(self):
-        self.adatpters = None
-        self.adapter_types: Dict[str, Type[Adapter]] = dict()
+        self.adatpters = {
+            "snowflake": {
+                "db_adapter": {"module": "core.adapters.impl", "class_name": "SnowflakeAdapter"},
+                "connection": {
+                    "module": "core.adapters.connection",
+                    "class_name": "SnowflakeConnection",
+                },
+                "credentials": {
+                    "module": "core.adapters.connection",
+                    "class_name": "SnowflakeCredentials",
+                },
+            }
+        }
+        self.adapter_name: str = str()
+
+    def register_adapter(self, profile: Profile) -> None:
+        adapter_to_register = profile.profile_dict["db_type"]
+        if adapter_to_register in self.adatpters.keys():
+            self.adapter_name = adapter_to_register
+        else:
+            raise NotImplementedError(f"{adapter_to_register} is not implemented in sheetwork.")
+
+    def load_plugins(
+        self,
+    ) -> Dict[str, Adapter]:
+        plugins_collection = {}
+        for plugin_type, module_info in self.adatpters[self.adapter_name].items():
+            module = importlib.import_module(module_info["module"])
+            plugins_collection[plugin_type] = getattr(module, module_info["class_name"])
+
+        return plugins_collection

--- a/core/adapters/factory.py
+++ b/core/adapters/factory.py
@@ -1,0 +1,10 @@
+from typing import Dict, Type
+from core.adapters.base.impl import BaseAdapter
+
+Adapter = BaseAdapter
+
+
+class AdapterContainer:
+    def __init__(self):
+        self.adatpters = None
+        self.adapter_types: Dict[str, Type[Adapter]] = dict()

--- a/core/adapters/impl.py
+++ b/core/adapters/impl.py
@@ -2,7 +2,6 @@ import tempfile
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import pandas
-from sqlalchemy.types import BOOLEAN, DATE, INTEGER, TIMESTAMP, VARCHAR, Numeric  # type: ignore
 from core.config.config import ConfigLoader
 from core.exceptions import DatabaseError, TableDoesNotExist
 from core.logger import GLOBAL_LOGGER as logger
@@ -27,22 +26,6 @@ class SnowflakeAdapter(BaseAdapter):
 
     def close_connection(self):
         self.con.close()
-
-    @staticmethod
-    def sqlalchemy_dtypes(dtypes_dict: Dict[str, Any]) -> Dict[str, Any]:
-        dtypes_dict = dtypes_dict.copy()
-        dtypes_map: Dict[str, Any] = dict(
-            varchar=VARCHAR,
-            int=INTEGER,
-            numeric=Numeric(38, 18),
-            boolean=BOOLEAN,
-            timestamp_ntz=TIMESTAMP,
-            date=DATE,
-        )
-
-        for col, data_type in dtypes_dict.items():
-            dtypes_dict.update({col: dtypes_map[data_type]})
-        return dtypes_dict
 
     def upload(self, df: pandas.DataFrame, override_schema: str = str()):
         # cast columns

--- a/core/adapters/impl.py
+++ b/core/adapters/impl.py
@@ -1,33 +1,32 @@
 import tempfile
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import Any, Optional
 
 import pandas
+
+# from core.utils import cast_pandas_dtypes
+from core.adapters.base.impl import BaseAdapter
+from core.adapters.connection import SnowflakeConnection
 from core.config.config import ConfigLoader
 from core.exceptions import DatabaseError, TableDoesNotExist
 from core.logger import GLOBAL_LOGGER as logger
 from core.ui.printer import green, timed_message
-from core.utils import cast_pandas_dtypes
-from core.adapters.base.impl import BaseAdapter
-
-if TYPE_CHECKING:
-    from core.adapters.connection import Connection
 
 
 class SnowflakeAdapter(BaseAdapter):
     """Interacts with snowflake via SQLAlchemy"""
 
-    def __init__(self, connection: "Connection", config: ConfigLoader):
+    def __init__(self, connection: SnowflakeConnection, config: ConfigLoader):
         self.connection = connection
         self.engine = connection.engine
         self.config = config
 
-    def acquire_connection(self):
+    def acquire_connection(self) -> None:
         self.con = self.engine.connect()
 
-    def close_connection(self):
+    def close_connection(self) -> None:
         self.con.close()
 
-    def upload(self, df: pandas.DataFrame, override_schema: str = str()):
+    def upload(self, df: pandas.DataFrame, override_schema: str = str()) -> None:
         # cast columns
         # ! temporarily deactivatiing df casting in pandas related to #205 & #204
         dtypes_dict = self.sqlalchemy_dtypes(self.config.sheet_columns)
@@ -70,7 +69,7 @@ class SnowflakeAdapter(BaseAdapter):
             temp.close()
             self.close_connection()
 
-    def execute(self, query: str, return_results: bool = False) -> Optional[Any]:
+    def excecute_query(self, query: str, return_results: bool = False) -> Optional[Any]:
         self.acquire_connection()
         results: Any = self.con.execute(query)
         if return_results:
@@ -80,7 +79,7 @@ class SnowflakeAdapter(BaseAdapter):
         self.close_connection()
         return None
 
-    def check_table(self, target_schema: str, target_table: str):
+    def check_table(self, target_schema: str, target_table: str) -> None:
         columns_query = f"""
                 select count(*)
                 from dwh.information_schema.columns
@@ -90,8 +89,8 @@ class SnowflakeAdapter(BaseAdapter):
                 ;
                 """
         rows_query = rows_query = f"select count(*) from {target_schema}.{target_table}"
-        columns = self.execute(columns_query, return_results=True)
-        rows = self.execute(rows_query, return_results=True)
+        columns = self.excecute_query(columns_query, return_results=True)
+        rows = self.excecute_query(rows_query, return_results=True)
         if columns and rows:
             logger.info(
                 timed_message(

--- a/core/adapters/impl.py
+++ b/core/adapters/impl.py
@@ -3,8 +3,9 @@ from typing import Any, Optional
 
 import pandas
 
+# ! temporarily deactivatiing df casting in pandas related to #205 & #204
 # from core.utils import cast_pandas_dtypes
-from core.adapters.base.impl import BaseAdapter
+from core.adapters.base.impl import BaseSQLAdapter
 from core.adapters.connection import SnowflakeConnection
 from core.config.config import ConfigLoader
 from core.exceptions import DatabaseError, TableDoesNotExist
@@ -12,7 +13,7 @@ from core.logger import GLOBAL_LOGGER as logger
 from core.ui.printer import green, timed_message
 
 
-class SnowflakeAdapter(BaseAdapter):
+class SnowflakeAdapter(BaseSQLAdapter):
     """Interacts with snowflake via SQLAlchemy"""
 
     def __init__(self, connection: SnowflakeConnection, config: ConfigLoader):
@@ -29,6 +30,7 @@ class SnowflakeAdapter(BaseAdapter):
     def upload(self, df: pandas.DataFrame, override_schema: str = str()) -> None:
         # cast columns
         # ! temporarily deactivatiing df casting in pandas related to #205 & #204
+        # df = cast_pandas_dtypes(df, overwrite_dict=self.config.sheet_columns)
         dtypes_dict = self.sqlalchemy_dtypes(self.config.sheet_columns)
 
         # potenfially override target schema from config.

--- a/core/adapters/impl.py
+++ b/core/adapters/impl.py
@@ -7,12 +7,14 @@ from core.config.config import ConfigLoader
 from core.exceptions import DatabaseError, TableDoesNotExist
 from core.logger import GLOBAL_LOGGER as logger
 from core.ui.printer import green, timed_message
+from core.utils import cast_pandas_dtypes
+from core.adapters.base.impl import BaseAdapter
 
 if TYPE_CHECKING:
     from core.adapters.connection import Connection
 
 
-class SnowflakeAdapter:
+class SnowflakeAdapter(BaseAdapter):
     """Interacts with snowflake via SQLAlchemy"""
 
     def __init__(self, connection: "Connection", config: ConfigLoader):

--- a/core/config/config.py
+++ b/core/config/config.py
@@ -65,8 +65,6 @@ class ConfigLoader:
             is_valid_yaml = validate_yaml(config_yaml, config_schema)
         if is_valid_yaml:
             self.config = config_yaml
-            print(self.config)
-            print(type(self.config))
             self.get_sheet_config()
             self._generate_column_type_override_dict()
             self._generate_column_rename_dict()
@@ -103,8 +101,6 @@ class ConfigLoader:
                     "Check your sheets.yml file."
                 )
             self.sheet_config = sheet_config[0]
-            print("SHEET CONFIG")
-            print(self.sheet_config)
             logger.debug(f"Sheet config dict: {self.sheet_config}")
             if self.sheet_config.get("columns"):
                 self.sheet_config["columns"] = [

--- a/core/config/profile.py
+++ b/core/config/profile.py
@@ -48,8 +48,6 @@ class Profile:
                     is_valid_profile = self._validate_profile(target_profile)
                     if is_valid_profile:
                         self.profile_dict = target_profile
-                        print("PROOOOOOOO")
-                        print(self.profile_dict)
                 else:
                     raise ProfileParserError(
                         f"Error finding and entry for  target: {self.target_name}, "

--- a/core/config/project.py
+++ b/core/config/project.py
@@ -41,8 +41,6 @@ class Project:
         is_valid_yaml = validate_yaml(project_yaml, project_schema)
         if project_yaml and is_valid_yaml:
             self.project_dict = project_yaml
-            print("PROJECT DICT")
-            print(self.project_dict)
             self.project_name = project_yaml.get("name", self.project_name)
             self.target_schema = project_yaml.get("target_schema", self.target_schema)
             if project_yaml.get("paths"):

--- a/tests/factory_test.py
+++ b/tests/factory_test.py
@@ -1,4 +1,3 @@
-import abc
 from pathlib import Path
 
 import pytest
@@ -8,10 +7,12 @@ FIXTURE_DIR = Path(__file__).resolve().parent
 
 @pytest.mark.datafiles(FIXTURE_DIR)
 def test_load_plugins(datafiles):
+    from core.adapters.base.connection import BaseConnection, BaseCredentials
+    from core.adapters.base.impl import BaseSQLAdapter
     from core.adapters.factory import AdapterContainer
-    from core.flags import FlagParser
     from core.config.profile import Profile
     from core.config.project import Project
+    from core.flags import FlagParser
     from core.main import parser
 
     flags = FlagParser(parser, project_dir=str(datafiles), profile_dir=str(datafiles))
@@ -21,9 +22,12 @@ def test_load_plugins(datafiles):
 
     a_c = AdapterContainer()
     a_c.register_adapter(profile)
-    plugins_dict = a_c.load_plugins()
-    allowed_adaptors = ["db_adapter", "connection", "credentials"]
-
-    for plugin_type, plugin in plugins_dict.items():
-        assert plugin_type in allowed_adaptors
-        assert isinstance(plugin, abc.ABCMeta)
+    a_c.load_plugins()
+    allowed_adaptors = {
+        "sql_adapter": BaseSQLAdapter,
+        "connection_adapter": BaseConnection,
+        "credentials_adapter": BaseCredentials,
+    }
+    for plugin_type, plugin_class in allowed_adaptors.items():
+        c_ada = getattr(a_c, plugin_type)
+        assert issubclass(c_ada, plugin_class)

--- a/tests/factory_test.py
+++ b/tests/factory_test.py
@@ -1,0 +1,29 @@
+import abc
+from pathlib import Path
+
+import pytest
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+
+
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_load_plugins(datafiles):
+    from core.adapters.factory import AdapterContainer
+    from core.flags import FlagParser
+    from core.config.profile import Profile
+    from core.config.project import Project
+    from core.main import parser
+
+    flags = FlagParser(parser, project_dir=str(datafiles), profile_dir=str(datafiles))
+    project = Project(flags, "sheetwork_test")
+    profile = Profile(project, "dev")
+    profile.read_profile()
+
+    a_c = AdapterContainer()
+    a_c.register_adapter(profile)
+    plugins_dict = a_c.load_plugins()
+    allowed_adaptors = ["db_adapter", "connection", "credentials"]
+
+    for plugin_type, plugin in plugins_dict.items():
+        assert plugin_type in allowed_adaptors
+        assert isinstance(plugin, abc.ABCMeta)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -14,7 +14,6 @@ def test_read_profile(datafiles):
     from core.flags import FlagParser
     from core.main import parser
 
-    print(FIXTURE_DIR)
     flags = FlagParser(parser, project_dir=str(datafiles), profile_dir=str(datafiles))
     project = Project(flags, "sheetwork_test")
     profile = Profile(project, "dev")


### PR DESCRIPTION
## Description
- Implements ABCs for `BaseSQLAdaptor`, `BaseConnection`, `BaseCredentials`
- Implements `AdaptorContainer` factory which "regusters" and loads concrete adaptors
- `SnowflakeAdaptor` now inherits from `BaseSQLAdaptor`
- `Credentials` is renamed to `BaseCredentials`
- `Connection` is remaled to `BaseConnection`
- `SnowflakeCresdentials` now inherits from `BaseCredentials`
- `SnowflakeConnection` now inherits from `BaseConnection`
- `pip` installer for github actions` now uses the new 2020 resolver to resolve one of the issues had at install.

## How has this change been tested?
Tested against a Snowflake instance with expected effects and unit tests are passing.
