### PR TITLE
feat(init_task): :fire: add option to force credentials folder

### DIFF
--- a/core/flags.py
+++ b/core/flags.py
@@ -27,6 +27,7 @@ class FlagParser:
         self.project_dir = project_dir
         self.target = "test"
         self.project_name = project_name
+        self.force_credentials = False
 
     def consume_cli_arguments(self):
         self.args = self.parser.parse_args()
@@ -46,6 +47,7 @@ class FlagParser:
             self.target = self.args.target
         if self.task == "init":
             self.project_name = self.args.project_name
+            self.force_credentials = self.args.force_credentials_folders
 
         self.log_level = self.args.log_level
         self.profile_dir = self.args.profile_dir

--- a/core/main.py
+++ b/core/main.py
@@ -78,6 +78,12 @@ init_sub = subs.add_parser(
 )
 init_sub.set_defaults(cls=init_task.InitTask, which="init")
 init_sub.add_argument("--project_name", help="Name you want to init your dbt project with")
+init_sub.add_argument(
+    "--force-credentials-folders",
+    action="store_true",
+    default=False,
+    help="Forces init task to at least attempt to create credential folders.",
+)
 
 
 def handle(parser: argparse.ArgumentParser):

--- a/core/task/init.py
+++ b/core/task/init.py
@@ -1,14 +1,11 @@
-from typing import TYPE_CHECKING
+import time
 from pathlib import Path
 
-from core.logger import GLOBAL_LOGGER as logger
+from core.clients.system import make_dir, make_file, open_dir_cmd
 from core.exceptions import ProjectIsAlreadyCreated
-from core.clients.system import open_dir_cmd, make_dir, make_file
-from core.ui.printer import green
-import time
-
 from core.flags import FlagParser
-
+from core.logger import GLOBAL_LOGGER as logger
+from core.ui.printer import green
 
 PROJECT_DOC_URL = "https://bastienboutonnet.gitbook.io/sheetwork/installation-and-configuration/untitled/set-up-your-sheetwork-project"
 PROFILE_DOC_URL = "https://bastienboutonnet.gitbook.io/sheetwork/installation-and-configuration/untitled/set-up-your-sheetwork-profile"

--- a/core/task/init.py
+++ b/core/task/init.py
@@ -7,8 +7,8 @@ from core.clients.system import open_dir_cmd, make_dir, make_file
 from core.ui.printer import green
 import time
 
-if TYPE_CHECKING:
-    from core.flags import FlagParser
+from core.flags import FlagParser
+
 
 PROJECT_DOC_URL = "https://bastienboutonnet.gitbook.io/sheetwork/installation-and-configuration/untitled/set-up-your-sheetwork-project"
 PROFILE_DOC_URL = "https://bastienboutonnet.gitbook.io/sheetwork/installation-and-configuration/untitled/set-up-your-sheetwork-profile"
@@ -25,6 +25,24 @@ Here is what happened behind the scenes:
 - If it was your first time setting up sheetwork on your machine, we also created a profiles.yml file
 
 What you need to do now:
+{to_do_credentials}
+
+Optionally:
+- You might want to change some defaults in your {project_path}/{project_name}.yml file. For help:
+    {project_doc_url}
+
+- You might want to configure a sheet to import in your sheets.yml file. For help:
+    {sheets_config_doc_url}
+"""
+
+CREDENTIALS_ONLY_SUCCESS_MESSAGE = """
+Alright! Your credential and profile files have been creeated ✨
+
+What you need to do now:
+{to_do_credentials}
+"""
+
+TO_DO_CREDENTIALS = """
 - Fill up your profiles.yml file. You can access it by running the following command:
 
     {open_cmd} {profiles_path}
@@ -34,13 +52,6 @@ What you need to do now:
 
 - You will need to fill up the {project_name}.json file with your google credentials key. For help see:
     {google_creds_doc_url}
-
-Optionally:
-- You might want to change some defaults in your {project_path}/{project_name}.yml file. For help:
-    {project_doc_url}
-
-- You might want to configure a sheet to import in your sheets.yml file. For help:
-    {sheets_config_doc_url}
 """
 
 PROFILES_PATH = Path("~/.sheetwork/").expanduser()
@@ -58,12 +69,13 @@ always_create: true
 
 
 class InitTask:
-    def __init__(self, flags: "FlagParser"):
+    def __init__(self, flags: FlagParser):
         self.flags = flags
         self.project_name: str = flags.project_name
         self.profiles_path: Path = PROFILES_PATH
         self.project_path: Path = PROJECT_PATH
         self.google_path: Path = Path()
+        self.project_dir_is_created = False
         self.assert_project_name()
 
     def assert_project_name(self):
@@ -108,11 +120,17 @@ class InitTask:
         project_dir = self.project_path / f"{self.project_name}"
         if not project_dir.exists():
             make_dir(project_dir)
+            self.project_dir_is_created = True
+        elif self.flags.force_credentials:
+            logger.warn(f"{self.project_name} already exists, moving on to credential files.")
         else:
             raise ProjectIsAlreadyCreated(
                 f"""\n
                 {self.project_name} already exists, so we'll stop.
                 If you created it by mistake, delete it and run this again.
+
+                If you want to generate the profiles and credentials files only use
+                --force-credentials-folders CLI arguments (see help for more info).
                 """
             )
 
@@ -125,22 +143,48 @@ class InitTask:
             make_file(full_path, project_file_content)
 
     def show_complete(self):
-        done_message = INIT_DONE.format(
-            project_name=self.project_name,
-            project_path=self.project_path,
+        credentials_message = TO_DO_CREDENTIALS.format(
+            to_do_credentials=TO_DO_CREDENTIALS,
+            open_cmd=open_dir_cmd(),
             profiles_path=self.profiles_path,
-            google_path=self.google_path,
             profiles_doc_url=PROFILE_DOC_URL,
             google_creds_doc_url=GOOGLE_CREDS_DOC_URL,
-            project_doc_url=PROJECT_DOC_URL,
-            sheets_config_doc_url=SHEETS_CONFIG_DOC_URL,
-            open_cmd=open_dir_cmd(),
+            project_name=self.project_name,
         )
+        if self.project_dir_is_created:
+            done_message = INIT_DONE.format(
+                project_name=self.project_name,
+                project_path=self.project_path,
+                profiles_path=self.profiles_path,
+                google_path=self.google_path,
+                profiles_doc_url=PROFILE_DOC_URL,
+                google_creds_doc_url=GOOGLE_CREDS_DOC_URL,
+                project_doc_url=PROJECT_DOC_URL,
+                sheets_config_doc_url=SHEETS_CONFIG_DOC_URL,
+                to_do_credentials=credentials_message,
+                open_cmd=open_dir_cmd(),
+            )
+        else:
+            done_message = CREDENTIALS_ONLY_SUCCESS_MESSAGE.format(
+                to_do_credentials=credentials_message
+            )
         logger.info(green(done_message))
 
     def run(self):
-        logger.info("❤️ Taking peantut butter and jelly out of the cupboard...🍇")
+        # print something cos it's fun!
+        print(
+            """
+           ______           __                  __
+          / __/ /  ___ ___ / /__    _____  ____/ /__
+         _\ \/ _ \/ -_) -_) __/ |/|/ / _ \/ __/  '_/
+        /___/_//_/\__/\__/\__/|__,__/\___/_/ /_/\_\\
+        """
+        )
+        logger.info("Alright let's get to work")
+        logger.info("❤️ Taking peanut butter and jelly out of the cupboard 🍇")
         time.sleep(3)
+
+        # do the actual work people cared about in the first place.
         self.override_paths()
         self.create_project_dir()
         self.create_project_file()


### PR DESCRIPTION
Allows to create the credential files for a project which has already being initialised (i.e. project folder and files exist) but for which credential files don't exist yet on a machine

Helps when using a shared codebase
