### PR TITLE
fix: :bug: disable df casting, drop `''` cols from dupe check

### DIFF
--- a/core/adapters/impl.py
+++ b/core/adapters/impl.py
@@ -8,7 +8,6 @@ from core.config.config import ConfigLoader
 from core.exceptions import DatabaseError, TableDoesNotExist
 from core.logger import GLOBAL_LOGGER as logger
 from core.ui.printer import green, timed_message
-from core.utils import cast_pandas_dtypes
 
 if TYPE_CHECKING:
     from core.adapters.connection import Connection
@@ -46,7 +45,7 @@ class SnowflakeAdapter:
 
     def upload(self, df: pandas.DataFrame, override_schema: str = str()):
         # cast columns
-        df = cast_pandas_dtypes(df, overwrite_dict=self.config.sheet_columns)
+        # ! temporarily deactivatiing df casting in pandas related to #205 & #204
         dtypes_dict = self.sqlalchemy_dtypes(self.config.sheet_columns)
 
         # potenfially override target schema from config.

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -2,7 +2,7 @@ requests<2.23.0
 gspread==3.3.0
 sqlalchemy==1.3.16
 cerberus==1.3.2
-pandas==1.0.4
+pandas==1.1.1
 pyyaml==5.3.1
 snowflake-sqlalchemy==1.2.3
 oauth2client==4.1.3

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "gspread==3.3.0",
         "sqlalchemy==1.3.16",
         "cerberus==1.3.2",
-        "pandas==1.0.4",
+        "pandas==1.1.1",
         "pyyaml==5.3.1",
         "snowflake-sqlalchemy==1.2.3",
         "oauth2client==4.1.3",

--- a/tests/sheets.yml
+++ b/tests/sheets.yml
@@ -86,3 +86,19 @@ sheets:
   - sheet_name: sheet_with_no_schema
     sheet_key: sample
     target_table: sample
+
+  - sheet_name: quality_assessment_scale
+    sheet_key: 1YyiUlZ4BNSADdO3LEz59gikEkmA3VmrktLOppgf-zqU
+    target_schema: ref_tables
+    target_table: quality_assessment_scale
+    columns:
+      - name: Needs_Improvement
+        datatype: int
+      - name: Acceptable
+        datatype: int
+      - name: Excellent
+        datatype: int
+      - name: N_A
+        datatype: int
+      - name: Fail
+        datatype: int

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,20 +1,10 @@
-from .mockers import CAST_DF, TO_CAST_DF, generate_test_df
+from .mockers import TO_CAST_DF, generate_test_df
 
 CASTING_DICT = {
     "col_int": "int",
     "col_varchar": "varchar",
     "created_date": "date",
 }
-
-
-def test_cast_pandas_dtypes():
-    from core.utils import cast_pandas_dtypes
-
-    to_cast = generate_test_df(TO_CAST_DF)
-    cast_df = cast_pandas_dtypes(to_cast, CASTING_DICT)
-    expected_cast = generate_test_df(CAST_DF)
-
-    assert cast_df.to_dict() == expected_cast.to_dict()
 
 
 def test_check_columns_in_df():


### PR DESCRIPTION
## Description
As explained in #204  and #205 pandas data types are a little too shaky at the minute so we're going to disable casting. This is a regression to pre `1.0.0` behaviour but it worked and at least Snowflake is doing a good job of casting dtypes.

## How has this change been tested?
functionality removed, unit tests passing

## Supporting doc, tickets, issues
Closes #205 
