### PR TITLE
fix: :lipstick: raise an erro when no command

### DIFF
--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -84,3 +84,7 @@ class ProjectIsAlreadyCreated(SheetWorkError):
 
 class MissnigInitProjectName(SheetWorkError):
     "when no project name is requested"
+
+
+class InvalidOrMissingCommandError(SheetWorkError):
+    "when no  command or invalid command is requested"

--- a/core/flags.py
+++ b/core/flags.py
@@ -1,3 +1,6 @@
+from core.exceptions import InvalidOrMissingCommandError
+
+
 class FlagParser:
     """Holds flags from args or sets up default ones that are mainly used to testing and delaying
     argument parsing from CLI so that pytest doesn't steal them and thinks they're for him and
@@ -45,10 +48,14 @@ class FlagParser:
             self.dry_run = self.args.dry_run
             self.sheet_config_dir = self.args.sheet_config_dir
             self.target = self.args.target
-        if self.task == "init":
+        elif self.task == "init":
             self.project_name = self.args.project_name
             self.force_credentials = self.args.force_credentials_folders
-
+        else:
+            raise InvalidOrMissingCommandError(
+                "No task or invalid task was provided. Run `sheetwork --help` to learn how to use sheetwork."
+            )
+        # put these out cos they apply to both tasks or would be escaped by error.
         self.log_level = self.args.log_level
         self.profile_dir = self.args.profile_dir
         self.project_dir = self.args.project_dir

--- a/core/task/init.py
+++ b/core/task/init.py
@@ -76,9 +76,7 @@ class InitTask:
 
     def assert_project_name(self):
         if not self.flags.project_name:
-            raise MissnigInitProjectName(
-                f"Please provide a project name to init your project with."
-            )
+            raise MissnigInitProjectName("Please provide a project name to init your project with.")
 
     def override_paths(self):
         if self.flags.profile_dir:


### PR DESCRIPTION
## Description

Throws an error when no command for a task is provided or when a non-implemented task is asked for.

## How has this change been tested?
Tests passed, and calling `sheetwork` without a task.

## Supporting doc, tickets, issues
Closes #200 