### PR TITLE
style: :lipstick: make debug console logger be more obvious

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-      - uses: actions/checkout@v1
+        uses: actions/checkout@v1
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v1

--- a/sheetwork/core/logger.py
+++ b/sheetwork/core/logger.py
@@ -9,6 +9,9 @@ class LogManager:
         log_to_console: bool = True,
     ):
         Path(log_file_path).mkdir(parents=True, exist_ok=True)
+
+        # setup colorlog
+
         log_filename = Path(log_file_path, "sheetwork_log.log")
         logger = logging.getLogger("Sheetwork Logger")
         logger.setLevel(logging.INFO)
@@ -20,8 +23,8 @@ class LogManager:
         f_format = logging.Formatter(
             "%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s"
         )
-        f_handler.setFormatter(f_format)
 
+        f_handler.setFormatter(f_format)
         # Add handlers to the logger
         logger.addHandler(f_handler)
 
@@ -34,11 +37,15 @@ class LogManager:
             logger.addHandler(c_handler)
 
         self.logger = logger
+        self.f_format = f_format
 
     def set_debug(self):
+        """Set all loggers to debug and make both the file and console logger have more informative
+        format"""
         self.logger.setLevel(logging.DEBUG)
         for handler in self.logger.handlers:
             handler.setLevel(logging.DEBUG)
+            handler.setFormatter(self.f_format)
 
 
 log_manager = LogManager()


### PR DESCRIPTION
## Description
When `--log-level` is set to `debug` the debug level stuff was also printed in the console. But it looked very bad and was hard to separate from the "pretty" print style.

In a way, I made it "uglier" by making the style of the console output in debug mode be really styled like a log message but I find that that's better and more transparent as to what is happening.
I might look into using [Rich](https://github.com/willmcgugan/rich) one of these days to make the experience of the CLI tool a lot better.

But for now it's clearer that way.
