### PR TITLE
refactor: :lipstick: shorter tracebacks and fix colouring

### DIFF
--- a/sheetwork/core/exceptions.py
+++ b/sheetwork/core/exceptions.py
@@ -3,7 +3,7 @@ from colorama import Fore
 
 class SheetWorkError(Exception):
     def __init__(self, message: str):
-        super().__init__(Fore.RED + message)  # type: ignore
+        super().__init__(f"{Fore.RED}{message}")
 
 
 class SheetWorkConfigMissingError(SheetWorkError):

--- a/sheetwork/core/flags.py
+++ b/sheetwork/core/flags.py
@@ -33,6 +33,7 @@ class FlagParser:
         self.target = "test"
         self.project_name = project_name
         self.force_credentials = False
+        self.full_tracebacks = False
 
     def consume_cli_arguments(self):
         self.args = self.parser.parse_args()
@@ -61,3 +62,4 @@ class FlagParser:
         self.log_level = self.args.log_level
         self.profile_dir = self.args.profile_dir
         self.project_dir = self.args.project_dir
+        self.full_tracebacks = self.args.full_tracebacks

--- a/sheetwork/core/main.py
+++ b/sheetwork/core/main.py
@@ -9,7 +9,11 @@ from sheetwork.core.config.profile import Profile
 from sheetwork.core.config.project import Project
 from sheetwork.core.flags import FlagParser
 from sheetwork.core.logger import log_manager
+from sheetwork.core.ui.traceback_manager import SheetworkTracebackManager
 from sheetwork.core.utils import check_and_compare_version
+
+# to identify sheetwork code --we use this arg in `core.logger to shorten the traceback`
+__SHEETWORK_CODE = True
 
 parser = argparse.ArgumentParser(
     prog="sheetwork",
@@ -30,6 +34,12 @@ base_subparser.add_argument(
     "--project-dir",
     help="Unusual path to the directory in which the 'sheetwork_project.yml' can be found",
     default=str(),
+)
+base_subparser.add_argument(
+    "--full-tracebacks",
+    action="store_true",
+    default=False,
+    help="When provided full tracebacks will be printed otherwise only the nearest one only.",
 )
 
 # Adds sub task parsers
@@ -90,6 +100,9 @@ init_sub.add_argument(
 def handle(parser: argparse.ArgumentParser):
     flag_parser = FlagParser(parser)
     flag_parser.consume_cli_arguments()
+
+    # set up traceback override
+    SheetworkTracebackManager(flag_parser)
 
     if flag_parser.log_level == "debug":
         log_manager.set_debug()

--- a/sheetwork/core/ui/traceback_manager.py
+++ b/sheetwork/core/ui/traceback_manager.py
@@ -17,8 +17,8 @@ class SheetworkTracebackManager:
         else:
 
             def is_mycode(tb):
-                globals = tb.tb_frame.f_globals
-                return globals.__contains__("__sheetwork_code")
+                globs = tb.tb_frame.f_globals
+                return globs.__contains__("__sheetwork_code")
 
             def mycode_traceback_levels(tb):
                 length = 0

--- a/sheetwork/core/ui/traceback_manager.py
+++ b/sheetwork/core/ui/traceback_manager.py
@@ -1,0 +1,38 @@
+import sys
+import traceback
+from sheetwork.core.flags import FlagParser
+
+
+class SheetworkTracebackManager:
+    """Consumes from flags whether user wants full tracebacks and sets up approproate skipping for
+    all tracebacks that are not part of the sheetwork code as identified by the __SHEETWORK_CODE
+    gobal which resides in main.py
+    """
+
+    def __init__(self, flags: FlagParser) -> None:
+        if flags.full_tracebacks:
+            # noop
+            pass
+
+        else:
+
+            def is_mycode(tb):
+                globals = tb.tb_frame.f_globals
+                return globals.__contains__("__sheetwork_code")
+
+            def mycode_traceback_levels(tb):
+                length = 0
+                while tb and is_mycode(tb):
+                    tb = tb.tb_next
+                length += 1
+                return length
+
+            def handle_exception(type, value, tb):
+                # 1. skip custom assert code, e.g.
+                # while tb and is_custom_assert_code(tb):
+                #   tb = tb.tb_next
+                # 2. only display your code
+                length = mycode_traceback_levels(tb)
+                print("".join(traceback.format_exception(type, value, tb, length)))
+
+            sys.excepthook = handle_exception


### PR DESCRIPTION
## Description

- feat: add flag for long TBs and implement TB manager
- refactor: handle connection error earlier
- fix: string concatenation of SheetWorkError


## How has this change been tested?
- tested the error messages pointed to in #209 traceback is either long or not depending on flag provided and errors are coloured as expected

## Supporting doc, tickets, issues
closes #209

