### PR TITLE
fix: :bug: reintroduce df casting, ignore ints

### DIFF
--- a/sheetwork/core/adapters/impl.py
+++ b/sheetwork/core/adapters/impl.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 import pandas
 
 # ! temporarily deactivatiing df casting in pandas related to #205 & #204
-# from core.utils import cast_pandas_dtypes
+from sheetwork.core.utils import cast_pandas_dtypes
 from sheetwork.core.adapters.base.impl import BaseSQLAdapter
 from sheetwork.core.adapters.connection import SnowflakeConnection
 from sheetwork.core.config.config import ConfigLoader
@@ -37,8 +37,8 @@ class SnowflakeAdapter(BaseSQLAdapter):
 
     def upload(self, df: pandas.DataFrame, override_schema: str = str()) -> None:
         # cast columns
-        # ! temporarily deactivatiing df casting in pandas related to #205 & #204
-        # df = cast_pandas_dtypes(df, overwrite_dict=self.config.sheet_columns)
+        # !: note integer conversion doesn't actually happen it is left as a str see #204, #205
+        df = cast_pandas_dtypes(df, overwrite_dict=self.config.sheet_columns)
         dtypes_dict = self.sqlalchemy_dtypes(self.config.sheet_columns)
 
         # potenfially override target schema from config.

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -58,7 +58,8 @@ TO_CAST_DF = {
 }
 
 CAST_DF = {
-    "col_int": {0: 1, 1: 2, 2: 32},
+    # this non conversion to int is intentional until we have a better fix see #205, #204
+    "col_int": {0: "1", 1: "2", 2: "32"},
     "col_varchar": {0: "foo", 1: "bar", 2: "fizz"},
     "created_date": {
         0: Timestamp("2019-01-01 00:00:00"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from .mockers import TO_CAST_DF, generate_test_df
+from .mockers import CAST_DF, TO_CAST_DF, generate_test_df
 
 CASTING_DICT = {
     "col_int": "int",
@@ -36,3 +36,13 @@ def test_check_and_compare_version(mocker):
     dummy_version = "0.0.0"
     needs_update = check_and_compare_version(dummy_version)
     assert needs_update is True
+
+
+def test_cast_pandas_dtypes():
+    from sheetwork.core.utils import cast_pandas_dtypes
+
+    to_cast = generate_test_df(TO_CAST_DF)
+    cast_df = cast_pandas_dtypes(to_cast, CASTING_DICT)
+    expected_cast = generate_test_df(CAST_DF)
+
+    assert cast_df.to_dict() == expected_cast.to_dict()


### PR DESCRIPTION
## Description

- feat: :bug: add date dtype casting (ignore casting to ints due to known issues with pandas see #204 and #205 
- test: add test for df casting

## How has this change been tested?
- updated unit tests

## Supporting doc, tickets, issues
closes #216

