### PR TITLE
feat: :lock: allow auth via end user credentials flow

### DIFF
--- a/changelog/231.feature.rst
+++ b/changelog/231.feature.rst
@@ -1,0 +1,2 @@
+* Users can now use their **end user/personal** account. Previously, it was only possible to authenticate using a **service_account**. Thanks for recent changes in `gspread` the auth flow allows for differenciation between end user and service account that is much simpler so we ported this to here https://github.com/burnash/gspread/pull/762
+* **Internal Note/Curiosity**: To make `oauth` work we had to patch `gspread`'s default credential paths (see https://github.com/burnash/gspread/issues/826). Hopefully, this is temporary.

--- a/sheetwork/core/clients/google.py
+++ b/sheetwork/core/clients/google.py
@@ -42,8 +42,6 @@ class GoogleSpreadsheet:
         self.client = profile.profile_dict.get("guser")
         self.is_authenticated: bool = False
 
-        # self._open_workbook()
-
     def _check_google_creds_exist(self) -> Tuple[bool, Path]:
         creds_path = Path(
             self._profile.google_credentials_dir, self._profile.profile_name
@@ -55,7 +53,6 @@ class GoogleSpreadsheet:
             f"'{self._profile.profile_name}' profile in the ~/.sheetwork/google/ folder. "
             "Check installation instructions if you do not know how to set this up."
         )
-        # return False, Path()
 
     def authenticate(self) -> None:
         if self.is_service_account:

--- a/sheetwork/core/clients/google.py
+++ b/sheetwork/core/clients/google.py
@@ -31,9 +31,15 @@ class GoogleSpreadsheet:
     """
 
     def __init__(self, profile: Profile, workbook_key: str = str(), workbook_name: str = str()):
+        self.is_service_account = profile.profile_dict.get("is_service_account", True)
         p = Path(profile.google_credentials_dir, profile.profile_name).with_suffix(".json")
         if p.exists():
-            self.gc = gspread.service_account(p)
+            if self.is_service_account:
+                logger.debug("Using SERVICE_ACCOUNT auth")
+                self.gc = gspread.service_account(p)
+            else:
+                logger.debug("Using END_USER auth")
+                self.gc = gspread.oauth(p)
         else:
             raise GoogleCredentialsFileMissingError(
                 "Sheetwork could not find a credentials file for your "

--- a/sheetwork/core/exceptions.py
+++ b/sheetwork/core/exceptions.py
@@ -88,3 +88,7 @@ class MissnigInitProjectName(SheetWorkError):
 
 class InvalidOrMissingCommandError(SheetWorkError):
     "when no  command or invalid command is requested"
+
+
+class GoogleClientNotAuthenticatedError(SheetWorkError):
+    "when you forgot to run authenticate or it failed"

--- a/sheetwork/core/sheetwork.py
+++ b/sheetwork/core/sheetwork.py
@@ -64,9 +64,10 @@ class SheetBag:
 
     def _obtain_googlesheet(self):
         worksheet = str(self.config.sheet_config.get("worksheet", str()))
-        df = GoogleSpreadsheet(self.profile, self.sheet_key).make_df_from_worksheet(
-            worksheet_name=worksheet
-        )
+        google_sheet = GoogleSpreadsheet(self.profile, self.sheet_key)
+        google_sheet.authenticate()
+        google_sheet.open_workbook()
+        df = google_sheet.make_df_from_worksheet(worksheet_name=worksheet)
         return df
 
     def load_sheet(self):

--- a/sheetwork/core/yaml/yaml_schema.py
+++ b/sheetwork/core/yaml/yaml_schema.py
@@ -64,6 +64,7 @@ profiles_schema = {
                             "warehouse": {"required": False, "type": "string"},
                             "schema": {"required": False, "type": "string"},
                             "guser": {"required": True, "type": "string"},
+                            "is_service_account": {"required": False, "type": "boolean"},
                         },
                     },
                 },

--- a/tests/google_test.py
+++ b/tests/google_test.py
@@ -38,7 +38,7 @@ def test__override_gspread_default_creds(datafiles, monkeypatch):
         pass
 
     monkeypatch.setattr(gspread.auth, "load_credentials", mock_load_credentials)
-    monkeypatch.setattr(gspread.auth, "store_credentials", mock_load_credentials)
+    monkeypatch.setattr(gspread.auth, "store_credentials", mock_store_credentials)
 
     project_name = "sheetwork_test"
     flags = FlagParser(parser, project_dir=str(datafiles), profile_dir=str(datafiles))

--- a/tests/google_test.py
+++ b/tests/google_test.py
@@ -1,0 +1,67 @@
+import logging
+
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+
+logger = logging.getLogger("testing logger")
+
+
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test__override_gspread_default_creds(datafiles, monkeypatch):
+    import gspread
+
+    from sheetwork.core.clients.google import GoogleSpreadsheet
+    from sheetwork.core.config.profile import Profile
+    from sheetwork.core.config.project import Project
+    from sheetwork.core.flags import FlagParser
+    from sheetwork.core.main import parser
+
+    # mock check for credentials so that we don't have to have a creds file in GH actions
+    def mock__check_google_creds_exist(self) -> Tuple[bool, Path]:
+        return True, Path("dummy")
+
+    monkeypatch.setattr(
+        GoogleSpreadsheet, "_check_google_creds_exist", mock__check_google_creds_exist
+    )
+
+    # Patch gspread functions so they don't attempt to do stuff
+    def mock_load_credentials(self) -> None:
+        pass
+
+    def mock_store_credentials(self) -> None:
+        pass
+
+    monkeypatch.setattr(gspread.auth, "load_credentials", mock_load_credentials)
+    monkeypatch.setattr(gspread.auth, "store_credentials", mock_load_credentials)
+
+    project_name = "sheetwork_test"
+    flags = FlagParser(parser, project_dir=str(datafiles), profile_dir=str(datafiles))
+    project = Project(flags, project_name=project_name)
+    # print(project.project_name)
+    profile = Profile(project, "end_user")
+    # print(profile.profile_name)
+    gsheet = GoogleSpreadsheet(profile)
+
+    # testing this also because who knows these might become deprecated
+    assert hasattr(gspread.auth, "DEFAULT_CONFIG_DIR")
+    assert hasattr(gspread.auth, "DEFAULT_CREDENTIALS_FILENAME")
+    assert hasattr(gspread.auth, "DEFAULT_AUTHORIZED_USER_FILENAME")
+    assert hasattr(gspread.auth, "DEFAULT_SERVICE_ACCOUNT_FILENAME")
+
+    # now make the replacements
+    gsheet._override_gspread_default_creds()
+    # dry_run=True)
+    g_creds_dir = profile.google_credentials_dir
+
+    assert gspread.auth.DEFAULT_CONFIG_DIR == g_creds_dir
+    assert gspread.auth.DEFAULT_CREDENTIALS_FILENAME == g_creds_dir.joinpath(f"{project_name}.json")
+    assert gspread.auth.DEFAULT_AUTHORIZED_USER_FILENAME == g_creds_dir.joinpath(
+        f"{project_name}_authorised_user.json"
+    )
+    assert gspread.auth.DEFAULT_SERVICE_ACCOUNT_FILENAME == g_creds_dir.joinpath(
+        f"{project_name}_service_account.json"
+    )

--- a/tests/google_test.py
+++ b/tests/google_test.py
@@ -30,9 +30,11 @@ def test__override_gspread_default_creds(datafiles, monkeypatch):
 
     # Patch gspread functions so they don't attempt to do stuff
     def mock_load_credentials(self) -> None:
+        # noop
         pass
 
     def mock_store_credentials(self) -> None:
+        # noop
         pass
 
     monkeypatch.setattr(gspread.auth, "load_credentials", mock_load_credentials)

--- a/tests/profiles.yml
+++ b/tests/profiles.yml
@@ -12,3 +12,14 @@ profiles:
         warehouse: f
         schema: g
         guser: sheetwork_test@blahh.iam.gserviceaccount.com
+      end_user:
+        db_type: snowflake
+        account: a
+        user: b
+        password: c
+        role: d
+        database: e
+        warehouse: f
+        schema: g
+        guser: sheetwork_test@blahh.iam.gserviceaccount.com
+        is_service_account: False

--- a/tests/sheets.yml
+++ b/tests/sheets.yml
@@ -21,7 +21,7 @@ sheets:
     excluded_columns: ["to_exclude", "col_not_in_df_for_fun"]
 
   - sheet_name: test_sheet_2
-    sheet_key: 10J52dhgTRqtI_lm4bf9B02nQu4zu5u6r0h2VIDTjRXg
+    sheet_key: 16nYKVY5UEKspYGbcMb5DG2GrOla-8HrvNOPIutKfdV4
     worksheet: Sheet2
     target_schema: sand
     target_table: bb_test_sheetwork


### PR DESCRIPTION
## Description
`gspread` has done an amazing work of reworking the google auth to support service account as well as end user authentication.

This PR is an attempt to use `gspread.oauth` to allow for end user authentication.

Currently as mentioned in https://github.com/burnash/gspread/issues/826 `oauth` cannot take a `filename` argument to look for credentials some place else and this currently "contradicts" with the setup of `sheetwork` qua credentials placement. We will have to wait and see if there is a possibility for `gspread.oauth` to take a filename and depending on this we can ship this feature.

## How has this change been tested?
Not tested yet, pending some clarity on https://github.com/burnash/gspread/issues/826 to decide how to move forward.

## Supporting doc, tickets, issues
Closes #227 
