### PR TITLE
chore: :broom: sort Python imports in pre-commit

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = cerberus,colorama,gspread,inflection,luddite,mock,numpy,packaging,pandas,pytest,snowflake,sqlalchemy,yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,12 @@
 repos:
-  - repo: https://github.com/ambv/black
-    rev: 20.8b1
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v2.2.0
     hooks:
-      - id: black
-        language_version: python3
-        args: [--line-length=100, --target-version=py37]
+      - id: seed-isort-config
+  - repo: https://github.com/timothycrosley/isort
+    rev: ''
+    hooks:
+      - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:
@@ -16,6 +18,11 @@ repos:
     rev: "aad0a7b"
     hooks:
       - id: mypy
-        exclude_types: [python]
         always_run: true
         args: [--ignore-missing-imports, "sheetwork/core"]
+  - repo: https://github.com/ambv/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3
+        args: [--line-length=100, --target-version=py37]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: mypy
         always_run: true
-        args: [--ignore-missing-imports, -p, sheetwork]
+        args: [--ignore-missing-imports, "sheetwork/core"]
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,18 @@ repos:
     rev: ''
     hooks:
       - id: isort
+  - repo: https://github.com/ambv/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3
+        args: [--line-length=100, --target-version=py37]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: ''
+    hooks:
+      - id: mypy
+        always_run: true
+        args: [--ignore-missing-imports, "sheetwork/core"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:
@@ -14,15 +26,3 @@ repos:
         exclude: ^.bumpversion.cfg
       - id: trailing-whitespace
         exclude: ^.bumpversion.cfg
-  - repo: git://github.com/luismayta/pre-commit-mypy
-    rev: "aad0a7b"
-    hooks:
-      - id: mypy
-        always_run: true
-        args: [--ignore-missing-imports, "sheetwork/core"]
-  - repo: https://github.com/ambv/black
-    rev: 20.8b1
-    hooks:
-      - id: black
-        language_version: python3
-        args: [--line-length=100, --target-version=py37]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,6 @@ repos:
       - id: mypy
         always_run: true
         args: [--ignore-missing-imports, -p, sheetwork]
-
-  # - repo: https://github.com/asottile/seed-isort-config
-  #   rev: v2.2.0
-  #   hooks:
-  #     - id: seed-isort-config
-  # - repo: https://github.com/timothycrosley/isort
-  #   rev: ''
-  #   hooks:
-  #     - id: isort
-  #       args: [--src=/sheetwork/]
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,27 @@
 repos:
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-  - repo: https://github.com/timothycrosley/isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
     rev: ''
     hooks:
-      - id: isort
+      - id: mypy
+        always_run: true
+        args: [--ignore-missing-imports]
+        files: ^sheetwork/
+  # - repo: https://github.com/asottile/seed-isort-config
+  #   rev: v2.2.0
+  #   hooks:
+  #     - id: seed-isort-config
+  # - repo: https://github.com/timothycrosley/isort
+  #   rev: ''
+  #   hooks:
+  #     - id: isort
+  #       args: [--src=/sheetwork/]
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:
       - id: black
         language_version: python3
         args: [--line-length=100, --target-version=py37]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: ''
-    hooks:
-      - id: mypy
-        always_run: true
-        args: [--ignore-missing-imports, "sheetwork/core"]
+        types: [python]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
       - id: mypy
         always_run: true
         args: [--ignore-missing-imports, -p, sheetwork]
-        # files: ^sheetwork/
 
   # - repo: https://github.com/asottile/seed-isort-config
   #   rev: v2.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,9 @@ repos:
     hooks:
       - id: mypy
         always_run: true
-        args: [--ignore-missing-imports]
-        files: ^sheetwork/
+        args: [--ignore-missing-imports, -p, sheetwork]
+        # files: ^sheetwork/
+
   # - repo: https://github.com/asottile/seed-isort-config
   #   rev: v2.2.0
   #   hooks:

--- a/sheetwork/core/adapters/impl.py
+++ b/sheetwork/core/adapters/impl.py
@@ -2,15 +2,15 @@ import tempfile
 from typing import Any, Optional
 
 import pandas
-
-# ! temporarily deactivatiing df casting in pandas related to #205 & #204
-from sheetwork.core.utils import cast_pandas_dtypes
 from sheetwork.core.adapters.base.impl import BaseSQLAdapter
 from sheetwork.core.adapters.connection import SnowflakeConnection
 from sheetwork.core.config.config import ConfigLoader
 from sheetwork.core.exceptions import DatabaseError, TableDoesNotExist
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
-from sheetwork.core.ui.printer import green, timed_message, red
+from sheetwork.core.ui.printer import green, red, timed_message
+
+# ! temporarily deactivatiing df casting in pandas related to #205 & #204
+from sheetwork.core.utils import cast_pandas_dtypes
 
 
 class SnowflakeAdapter(BaseSQLAdapter):

--- a/sheetwork/core/clients/system.py
+++ b/sheetwork/core/clients/system.py
@@ -1,5 +1,6 @@
 import sys
 from typing import TYPE_CHECKING
+
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
 
 if TYPE_CHECKING:

--- a/sheetwork/core/ui/printer.py
+++ b/sheetwork/core/ui/printer.py
@@ -1,6 +1,6 @@
 import time
-from sheetwork.core.ui.colours import COLOURS
 
+from sheetwork.core.ui.colours import COLOURS
 
 USE_COLOURS = True
 PRINTER_WIDTH = 80

--- a/sheetwork/core/ui/traceback_manager.py
+++ b/sheetwork/core/ui/traceback_manager.py
@@ -1,5 +1,6 @@
 import sys
 import traceback
+
 from sheetwork.core.flags import FlagParser
 
 


### PR DESCRIPTION
## Description
Adds `isort` to precommit hooks so that I can automate import sorting for this project
