### PR TITLE
chore: CI add mypy and isort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ sheetwork_logs/
 *.whl
 
 **/typings/
+
+requirements.txt
+dev-requirements.txt

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = cerberus,colorama,gspread,inflection,luddite,mock,numpy,packaging,pandas,pytest,snowflake,sqlalchemy,yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: ''
     hooks:
       - id: isort
-        args: ["-m3", "-w 100"]
+        args: ["sheetwork/core", "-m3", "-w 100"]
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: ''
     hooks:
       - id: isort
-        args: ["-m3", "--tc", "-w 100"]
+        args: ["-m3", "-w 100"]
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,13 @@
 repos:
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v2.2.0
+    hooks:
+      - id: seed-isort-config
+  - repo: https://github.com/PyCQA/isort
+    rev: ''
+    hooks:
+      - id: isort
+        args: ["-m3", "--tc", "-w 100"]
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,5 +29,5 @@ repos:
     rev: ''
     hooks:
       - id: isort
-        args: ["-m3", "-w 100"]
+        args: ["-m3", "-w 100", "--tc"]
         exclude: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v2.2.0
     hooks:
       - id: seed-isort-config
+        name: Seed isort
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:
@@ -29,5 +30,6 @@ repos:
     rev: ''
     hooks:
       - id: isort
+        name: Sort import with isort
         args: ["-m3", "-w 100", "--tc"]
         exclude: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,6 @@ repos:
     rev: v2.2.0
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/PyCQA/isort
-    rev: ''
-    hooks:
-      - id: isort
-        args: ["-m3", "-w 100"]
-        exclude: ^tests/
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:
@@ -31,3 +25,9 @@ repos:
         entry: mypy sheetwork/core
         pass_filenames: false
         args: [--ignore-missing-imports]
+  - repo: https://github.com/PyCQA/isort
+    rev: ''
+    hooks:
+      - id: isort
+        args: ["-m3", "-w 100"]
+        exclude: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,8 @@ repos:
     rev: ''
     hooks:
       - id: isort
-        args: ["sheetwork/core", "-m3", "-w 100"]
+        args: ["-m3", "-w 100"]
+        exclude: ^tests/
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/bastienboutonnet/sheetwork?include_prereleases) [![codecov](https://codecov.io/gh/bastienboutonnet/sheetwork/branch/dev%2Fnicolas_jaar/graph/badge.svg)](https://codecov.io/gh/bastienboutonnet/sheetwork)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
+[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 ![Sheetwork Build](https://github.com/bastienboutonnet/sheetwork/workflows/Sheetwork%20CI/badge.svg)
 ![python](https://img.shields.io/badge/python-3.7%20%7C%203.8-blue)
 [![Discord](https://img.shields.io/discord/752101657218908281?label=discord)](https://discord.gg/ebSTWq)

--- a/sheetwork/core/adapters/impl.py
+++ b/sheetwork/core/adapters/impl.py
@@ -3,14 +3,13 @@ from typing import Any, Optional
 
 import pandas
 
-# ! temporarily deactivatiing df casting in pandas related to #205 & #204
-from sheetwork.core.utils import cast_pandas_dtypes
 from sheetwork.core.adapters.base.impl import BaseSQLAdapter
 from sheetwork.core.adapters.connection import SnowflakeConnection
 from sheetwork.core.config.config import ConfigLoader
 from sheetwork.core.exceptions import DatabaseError, TableDoesNotExist
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
-from sheetwork.core.ui.printer import green, timed_message, red
+from sheetwork.core.ui.printer import green, red, timed_message
+from sheetwork.core.utils import cast_pandas_dtypes
 
 
 class SnowflakeAdapter(BaseSQLAdapter):

--- a/sheetwork/core/clients/system.py
+++ b/sheetwork/core/clients/system.py
@@ -1,5 +1,6 @@
 import sys
 from typing import TYPE_CHECKING
+
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
 
 if TYPE_CHECKING:

--- a/sheetwork/core/ui/printer.py
+++ b/sheetwork/core/ui/printer.py
@@ -1,6 +1,6 @@
 import time
-from sheetwork.core.ui.colours import COLOURS
 
+from sheetwork.core.ui.colours import COLOURS
 
 USE_COLOURS = True
 PRINTER_WIDTH = 80

--- a/sheetwork/core/ui/traceback_manager.py
+++ b/sheetwork/core/ui/traceback_manager.py
@@ -1,5 +1,6 @@
 import sys
 import traceback
+
 from sheetwork.core.flags import FlagParser
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -41,9 +41,8 @@ def test_set_config(datafiles):
 @pytest.mark.datafiles(FIXTURE_DIR)
 def test__override_cli_args(datafiles):
     from sheetwork.core.config.config import ConfigLoader
-
-    from sheetwork.core.main import parser
     from sheetwork.core.config.project import Project
+    from sheetwork.core.main import parser
 
     flags = FlagParser(
         parser,

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -42,8 +42,8 @@ def test_set_config(datafiles):
 def test__override_cli_args(datafiles):
     from sheetwork.core.config.config import ConfigLoader
 
-    from sheetwork.core.config.project import Project
     from sheetwork.core.main import parser
+    from sheetwork.core.config.project import Project
 
     flags = FlagParser(
         parser,


### PR DESCRIPTION
## Description
Was able to ensure that `isort` can sort imports in a similar way to black by reading this article: https://copdips.com/2020/04/making-isort-compatible-with-black.html