### PR TITLE
fix: :bug: set global logger to DEBUG always

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         name: Sort import with isort
         args: ["-m3", "-w 100", "--tc"]
         exclude: ^tests/
-  - repo: https://github.com/prettier/prettier
+  - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "" # Use the sha or tag you want to point at
     hooks:
       - id: prettier

--- a/sheetwork/core/logger.py
+++ b/sheetwork/core/logger.py
@@ -14,7 +14,9 @@ class LogManager:
 
         log_filename = Path(log_file_path, "sheetwork_log.log")
         logger = logging.getLogger("Sheetwork Logger")
-        logger.setLevel(logging.INFO)
+        # set the logger to the lowest level (then each handler will have it's level --this ensures
+        # that all logging always ends up in the file logger.)
+        logger.setLevel(logging.DEBUG)
         # Create handlers
         f_handler = logging.FileHandler(log_filename)
         f_handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Description
As mentioned in #230 the logger was only printing `DEBUG` level logs to the log file if we had actually asked specifically for `--log-level debug` in the CLI.

This was because the logger was defined with default level `INFO` which meant that it would filter out the message anyway even if the file handler was set up to log anything up from `DEBUG`.

I have now made the global logger level be `DEBUG`, then the console and file handler to the proper filtering of the logs and this means **logger always sends DEBUG info to the file no matter what**

## How has this change been tested?
Tested with a test sheet and logs working fine
Pytest seems happy too, so it looks like I didn't break anything

## Supporting doc, tickets, issues
Closes #230 
