### PR TITLE
feat: fully qualify target names

### DIFF
--- a/sheetwork/core/config/config.py
+++ b/sheetwork/core/config/config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import Any, Dict, List, Union
 
 from sheetwork.core.config.project import Project
 from sheetwork.core.exceptions import (

--- a/sheetwork/core/config/config.py
+++ b/sheetwork/core/config/config.py
@@ -7,17 +7,15 @@ from sheetwork.core.exceptions import (
     SheetWorkConfigMissingError,
     TargetSchemaMissing,
 )
+from sheetwork.core.flags import FlagParser
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
 from sheetwork.core.ui.printer import yellow
 from sheetwork.core.yaml.yaml_helpers import open_yaml, validate_yaml
 from sheetwork.core.yaml.yaml_schema import config_schema
 
-if TYPE_CHECKING:
-    from core.flags import FlagParser
-
 
 class ConfigLoader:
-    def __init__(self, flags: "FlagParser", project: Project):
+    def __init__(self, flags: FlagParser, project: Project):
         self.config: Dict[str, List[Dict[str, Any]]] = dict()
         self.sheet_config: Dict[str, Union[str, bool, List[Union[str, Dict[str, str]]]]] = dict(
             sheet_key=flags.sheet_key,


### PR DESCRIPTION
## Description
As requested in #245 we want to print the database name in the success messages of the table pushes.
This unearthed a few ugly harcoded things which didn't really cause issues but it's good that we caugh it.

Namely the queries in `check_table()` against the info schema have been rewritten to actually populate all db references dynamically.

This should make things a bit nicer and safer for now.

## How has this change been tested?
Tested in local dev runs + `pytest` seems all good.

## Supporting doc, tickets, issues
Closes #245 