### PR TITLE
feat: :mage: allow for schema creation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,10 +37,10 @@ repos:
     rev: "" # Use the sha or tag you want to point at
     hooks:
       - id: prettier
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: "" # pick a git hash / tag to point to
-    hooks:
-      - id: flake8
-        exclude: ^tests/
-        additional_dependencies: [flake8-docstrings]
-        args: ["--max-line-length=120", "--ignore=D102"]
+  # - repo: https://gitlab.com/pycqa/flake8
+  #   rev: "" # pick a git hash / tag to point to
+  #   hooks:
+  #     - id: flake8
+  #       exclude: ^tests/
+  #       additional_dependencies: [flake8-docstrings]
+  #       args: ["--max-line-length=120", "--ignore=D102"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,10 @@ repos:
     rev: "" # Use the sha or tag you want to point at
     hooks:
       - id: prettier
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: "" # pick a git hash / tag to point to
+    hooks:
+      - id: flake8
+        exclude: ^tests/
+        additional_dependencies: [flake8-docstrings]
+        args: ["--max-line-length=120", "--ignore=D102"]

--- a/sheetwork/core/adapters/impl.py
+++ b/sheetwork/core/adapters/impl.py
@@ -8,7 +8,7 @@ from sheetwork.core.adapters.connection import SnowflakeConnection
 from sheetwork.core.config.config import ConfigLoader
 from sheetwork.core.exceptions import DatabaseError, TableDoesNotExist
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
-from sheetwork.core.ui.printer import green, red, timed_message
+from sheetwork.core.ui.printer import green, red, timed_message, yellow
 from sheetwork.core.utils import cast_pandas_dtypes
 
 
@@ -76,9 +76,12 @@ class SnowflakeAdapter(BaseSQLAdapter):
                 except ValueError as e:
                     if _if_exists == "fail":
                         logger.warning(
-                            f"{self.connection.credentials.credentials.get('database')}"
-                            f".{schema}.{self.config.target_table} already exists and was not "
-                            "recreated because 'destructive_create_table' is set to False in your profile"
+                            yellow(
+                                f"{self.connection.credentials.credentials.get('database')}"
+                                f".{schema}.{self.config.target_table} already exists and was not\n"
+                                "recreated because 'destructive_create_table' is set to False in your profile \n"
+                                "APPENDING instead."
+                            )
                         )
                     else:
                         raise DatabaseError(str(e))

--- a/sheetwork/core/adapters/impl.py
+++ b/sheetwork/core/adapters/impl.py
@@ -1,3 +1,4 @@
+"""Module containing all Database Specific classes."""
 import tempfile
 from typing import Any, Optional
 
@@ -13,9 +14,17 @@ from sheetwork.core.utils import cast_pandas_dtypes
 
 
 class SnowflakeAdapter(BaseSQLAdapter):
-    """Interacts with snowflake via SQLAlchemy"""
+    """Interacts with snowflake via SQLAlchemy."""
 
     def __init__(self, connection: SnowflakeConnection, config: ConfigLoader):
+        """Contstructs the Snowflake DB Adaptor.
+
+        Args:
+            connection (SnowflakeConnection): connection object containing credentials and
+                connection variables needed for Snowflake.
+            config (ConfigLoader): configuration class containing all params for sheetwork general
+                operation
+        """
         self.connection = connection
         self.engine = connection.engine
         self.config = config
@@ -25,7 +34,7 @@ class SnowflakeAdapter(BaseSQLAdapter):
         try:
             self.con = self.engine.connect()
         except Exception:
-            raise DatabaseError(red(f"Error creating Snowflake connection."))
+            raise DatabaseError(red("Error creating Snowflake connection."))
 
     def close_connection(self) -> None:
         try:

--- a/sheetwork/core/config/project.py
+++ b/sheetwork/core/config/project.py
@@ -1,8 +1,10 @@
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Union
 
 from sheetwork.core.exceptions import ProjectFileParserError
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
+from sheetwork.core.ui.printer import red
 from sheetwork.core.utils import PathFinder
 from sheetwork.core.yaml.yaml_helpers import open_yaml, validate_yaml
 from sheetwork.core.yaml.yaml_schema import project_schema
@@ -10,11 +12,14 @@ from sheetwork.core.yaml.yaml_schema import project_schema
 if TYPE_CHECKING:
     from sheetwork.core.flags import FlagParser
 
-PROJECT_FILENAME = "sheetwork_project.yml"
-
 
 class Project:
     """Sets up everything there is to know about the project config."""
+
+    PROJECT_FILENAME = "sheetwork_project.yml"
+    # this is some garbage to make sure we don't sleep when we test the deprecation handling
+    # ! DEPRECATION
+    IS_TEST = False
 
     def __init__(self, flags: "FlagParser", project_name: str = str()):
         self.project_name = project_name
@@ -33,11 +38,16 @@ class Project:
         # override defaults
         self.override_from_flags()
         self.load_project_from_yaml()
+        self.decide_object_creation()
         logger.debug(f"Project name: {self.project_name}")
+
+        self.is_test: bool = False
 
     def load_project_from_yaml(self):
         if self.project_file_fullpath == Path("dumpy_path"):
-            _, self.project_file_fullpath = PathFinder().find_nearest_dir_and_file(PROJECT_FILENAME)
+            _, self.project_file_fullpath = PathFinder().find_nearest_dir_and_file(
+                type(self).PROJECT_FILENAME
+            )
         project_yaml = open_yaml(self.project_file_fullpath)
         is_valid_yaml = validate_yaml(project_yaml, project_schema)
         if project_yaml and is_valid_yaml:
@@ -64,17 +74,22 @@ class Project:
     # ! DEPRECATION
     def handle_deprecations(self) -> None:
         if self.project_dict.get("always_create"):
-            logger.warning(
-                "DEPRECATION WANING: 'always_create' will be deprecated in a future major release\n"
+            msg = (
+                "\nDEPRECATION WANING: 'always_create' will be deprecated in a future major release\n"
                 "'always_create' now means 'always_create_table'. \n"
                 "Prefer using 'always_create_table' instead or 'always_create_all_objects' if you \n"
                 "want to make sheetwork create all objects (database, schemas and tables)."
             )
 
+            logger.warning(red(msg))
+            if type(self).IS_TEST is False:
+                time.sleep(4)
+
     def decide_object_creation(self) -> None:
         self.handle_deprecations()
         create_everything_label = "always_create_objects"
         object_creation_mapping = {
+            # ! DEPRECATE "always_create"
             "create_table": ["always_create_table", "always_create", create_everything_label],
             "create_schema": ["alwayws_create_schema", create_everything_label],
             "create_database": ["always_create_database", create_everything_label],
@@ -94,7 +109,7 @@ class Project:
 
     def override_from_flags(self):
         if self.flags.project_dir:
-            self.project_file_fullpath = Path(self.flags.project_dir, PROJECT_FILENAME)
+            self.project_file_fullpath = Path(self.flags.project_dir, type(self).PROJECT_FILENAME)
         if self.flags.profile_dir:
             self.profile_dir = Path(self.flags.profile_dir)
         if self.flags.sheet_config_dir:

--- a/sheetwork/core/config/project.py
+++ b/sheetwork/core/config/project.py
@@ -41,8 +41,6 @@ class Project:
         self.decide_object_creation()
         logger.debug(f"Project name: {self.project_name}")
 
-        self.is_test: bool = False
-
     def load_project_from_yaml(self):
         if self.project_file_fullpath == Path("dumpy_path"):
             _, self.project_file_fullpath = PathFinder().find_nearest_dir_and_file(

--- a/sheetwork/core/config/project.py
+++ b/sheetwork/core/config/project.py
@@ -21,6 +21,7 @@ class Project:
         self.project_dict: Dict[str, Union[str, bool]] = dict()
         self.target_schema: str = str()
         self.object_creation_dct: Dict[str, bool] = dict()
+        self.destructive_create_table: bool = False
         self.flags = flags
 
         # directories (first overwritten by flags, then by project) This may not always be able to
@@ -84,6 +85,12 @@ class Project:
             else:
                 create = [True for x in rule if self.project_dict.get(x) is True]
             self.object_creation_dct.update({object: True in create})
+        self.destructive_create_table = (
+            True
+            if self.project_dict.get("destructive_create_table", self.destructive_create_table)
+            is True
+            else False
+        )
 
     def override_from_flags(self):
         if self.flags.project_dir:

--- a/sheetwork/core/task/init.py
+++ b/sheetwork/core/task/init.py
@@ -60,8 +60,9 @@ name: '{project_name}'
 # change the following to your default destination schema
 target_schema: 'sandbox'
 
-# we set sheetwork to always create tables, feel free to set that to false if you don't like it.
-always_create: true
+# we set sheetwork to always create ALL objects (database, schema, tabke),
+# feel free to set that to false if you don't like it.
+always_create_objects: true
 """
 
 

--- a/sheetwork/core/yaml/yaml_schema.py
+++ b/sheetwork/core/yaml/yaml_schema.py
@@ -77,6 +77,10 @@ project_schema = {
     "name": {"required": True, "type": "string"},
     "target_schema": {"required": False, "type": "string"},
     "always_create": {"required": False, "type": "boolean"},
+    "always_create_table": {"required": False, "type": "boolean"},
+    "always_create_schema": {"required": False, "type": "boolean"},
+    "always_create_database": {"required": False, "type": "boolean"},
+    "always_create_objects": {"required": False, "type": "boolean"},
     "paths": {
         "type": "dict",
         "required": False,

--- a/sheetwork/core/yaml/yaml_schema.py
+++ b/sheetwork/core/yaml/yaml_schema.py
@@ -81,6 +81,7 @@ project_schema = {
     "always_create_schema": {"required": False, "type": "boolean"},
     "always_create_database": {"required": False, "type": "boolean"},
     "always_create_objects": {"required": False, "type": "boolean"},
+    "destructive_create_table": {"required": False, "type": "boolean"},
     "paths": {
         "type": "dict",
         "required": False,

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -37,7 +37,8 @@ NO_COLS_EXPECTED_CONFIG = {
 EXPECTED_SHEETWORK_PROJECT = {
     "name": "sheetwork_test",
     "target_schema": "sand",
-    "always_create": True,
+    "always_create_table": True,
+    "destructive_create_table": True,
 }
 
 DIRTY_DF = {

--- a/tests/project_test.py
+++ b/tests/project_test.py
@@ -18,3 +18,33 @@ def test_load_project_from_yaml(datafiles):
     project.load_project_from_yaml()
 
     assert project.project_dict == EXPECTED_SHEETWORK_PROJECT
+
+
+@pytest.mark.parametrize(
+    "project_name",
+    ["sheetwork_project", "sheetwork_project_all_create", "sheetwork_project_deprecated"],
+)
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_decide_object_creation(monkeypatch, datafiles, project_name):
+    from sheetwork.core.flags import FlagParser
+    from sheetwork.core.config.project import Project
+    from sheetwork.core.main import parser
+
+    monkeypatch.setattr(Project, "PROJECT_FILENAME", f"{project_name}.yml")
+    monkeypatch.setattr(Project, "IS_TEST", True)
+
+    expected_object_creation_dict = {
+        "create_table": True,
+        "create_schema": False,
+        "create_database": False,
+    }
+
+    if project_name == "sheetwork_project_all_create":
+        expected_object_creation_dict = {val: True for val in expected_object_creation_dict}
+
+    flags = FlagParser(parser, project_dir=str(datafiles))
+    project = Project(flags, project_name=project_name)
+    project.decide_object_creation()
+
+    assert project.object_creation_dct == expected_object_creation_dict
+    assert project.destructive_create_table is True

--- a/tests/sheetwork_project_all_create.yml
+++ b/tests/sheetwork_project_all_create.yml
@@ -1,4 +1,4 @@
 name: "sheetwork_test"
 target_schema: "sand"
-always_create_table: true
+always_create_objects: true
 destructive_create_table: true

--- a/tests/sheetwork_project_deprecated.yml
+++ b/tests/sheetwork_project_deprecated.yml
@@ -1,4 +1,4 @@
 name: "sheetwork_test"
 target_schema: "sand"
-always_create_table: true
+always_create: true
 destructive_create_table: true


### PR DESCRIPTION
## Description
- Makes the following profile arguments for object creation available:
	- `always_create_table`: when true, tables will be created if they don't exist (and replaced if `destructive_create_table` is `True` --see below)
	- `always_create_schema`: when true, schemas will be created (noop yet --this will follow in another PR. At the moment schema and table creation are happening together)
	- `always_create_db`: when true a `create database if not exist` will be called (noop yet --this will follow in another PR).
	- `destructive_create_table`: when true, if the target table exists already it will be dropped/replaced entirely.
	- `always_create_objects`: when true all objects will be created if they do not exist, with the exception of **tables** will not be recreated unless `destructive_create_table` --see above-- is `True`

- `always_create` now throws a `DEPRECATION_WARNING` and is remapped to the `always_create_table` argument. The remapping happens behind the scenes and is **backwards compatible** but a major version will deprecate this argument.

## How has this change been tested?
Unit tests in place + tested against Snowflake instance.

## Supporting doc, tickets, issues
Closes #251 
