### PR TITLE
feat: :mage: implement schema creation

### DIFF
--- a/changelog/262.feature.rst
+++ b/changelog/262.feature.rst
@@ -1,0 +1,1 @@
+The target schema now gets created if `always_create_schema` is `True`. Under the hood: SnowflakeAdaptor checks if the schema already exists on the database before creating it.

--- a/sheetwork/core/config/project.py
+++ b/sheetwork/core/config/project.py
@@ -88,9 +88,9 @@ class Project:
         create_everything_label = "always_create_objects"
         object_creation_mapping = {
             # ! DEPRECATE "always_create"
-            "create_table": ["always_create_table", "always_create", create_everything_label],
-            "create_schema": ["alwayws_create_schema", create_everything_label],
-            "create_database": ["always_create_database", create_everything_label],
+            "create_table": ["always_create_table", "always_create"],
+            "create_schema": ["always_create_schema"],
+            "create_database": ["always_create_database"],
         }
         for object, rule in object_creation_mapping.items():
             if self.project_dict.get(create_everything_label):

--- a/sheetwork/core/exceptions.py
+++ b/sheetwork/core/exceptions.py
@@ -66,6 +66,10 @@ class DatabaseError(SheetWorkError):
     "To catch db interaction errors"
 
 
+class NoAcquiredConnectionError(SheetWorkError):
+    "For when no connection has been acquied"
+
+
 class TableDoesNotExist(SheetWorkError):
     "When query for rows and cols came back empty or none"
 

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -38,6 +38,7 @@ EXPECTED_SHEETWORK_PROJECT = {
     "name": "sheetwork_test",
     "target_schema": "sand",
     "always_create_table": True,
+    "always_create_schema": True,
     "destructive_create_table": True,
 }
 

--- a/tests/project_test.py
+++ b/tests/project_test.py
@@ -35,7 +35,7 @@ def test_decide_object_creation(monkeypatch, datafiles, project_name):
 
     expected_object_creation_dict = {
         "create_table": True,
-        "create_schema": False,
+        "create_schema": True,
         "create_database": False,
     }
 

--- a/tests/sheetwork_project.yml
+++ b/tests/sheetwork_project.yml
@@ -1,4 +1,5 @@
 name: "sheetwork_test"
 target_schema: "sand"
 always_create_table: true
+always_create_schema: true
 destructive_create_table: true

--- a/tests/sheetwork_project_deprecated.yml
+++ b/tests/sheetwork_project_deprecated.yml
@@ -1,4 +1,5 @@
 name: "sheetwork_test"
 target_schema: "sand"
 always_create: true
+always_create_schema: true
 destructive_create_table: true


### PR DESCRIPTION

## Description

- call `_create_schema` before table creation. This function first checks if a schema exists in the specified database and if it does not it gets created. 

- simplify object_creation_mapping

## How has this change been tested?
Tested against Snowflake instance + updated `pytests` for object creation mapping

## Supporting doc, tickets, issues

Closes #260

