### PR TITLE
feat: allow object creation CLI override

### DIFF
--- a/changelog/265.feature.rst
+++ b/changelog/265.feature.rst
@@ -1,0 +1,11 @@
+ In order to override (or set on demand) object creation (tables and schemas) we now provide the following CLI arguments:
+- `create-table`
+- `create-schema`
+- `destructive-create-table`
+
+These arguments are "companions" which can override the following project configuration arguments:
+- `always_create_table`
+- `always_create_schema`
+- `destructive_create_table`
+
+**IMPORTANT**:CLI flags will override whatever is already present in the project config

--- a/sheetwork/core/adapters/connection.py
+++ b/sheetwork/core/adapters/connection.py
@@ -67,13 +67,14 @@ class SnowflakeConnection(BaseConnection):
         self.generate_engine()
 
     def generate_engine(self):
-        self.url = URL(
-            account=self.credentials.credentials.get("account"),
-            user=self.credentials.credentials.get("user"),
-            password=self.credentials.credentials.get("password"),
-            role=self.credentials.credentials.get("role"),
-            warehouse=self.credentials.credentials.get("warehouse"),
-            database=self.credentials.credentials.get("database"),
-            schema=self.credentials.credentials.get("schema"),
+        self.engine = create_engine(
+            URL(
+                account=self.credentials.credentials.get("account"),
+                user=self.credentials.credentials.get("user"),
+                password=self.credentials.credentials.get("password"),
+                role=self.credentials.credentials.get("role"),
+                warehouse=self.credentials.credentials.get("warehouse"),
+                database=self.credentials.credentials.get("database"),
+                schema=self.credentials.credentials.get("schema"),
+            )
         )
-        self.engine = create_engine(self.url)

--- a/sheetwork/core/config/project.py
+++ b/sheetwork/core/config/project.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, Union
 
 from sheetwork.core.exceptions import ProjectFileParserError
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
-from sheetwork.core.ui.printer import red
+from sheetwork.core.ui.printer import red, yellow
 from sheetwork.core.utils import PathFinder
 from sheetwork.core.yaml.yaml_helpers import open_yaml, validate_yaml
 from sheetwork.core.yaml.yaml_schema import project_schema
@@ -36,9 +36,10 @@ class Project:
         self.sheet_config_dir: Path = Path.cwd()
 
         # override defaults
-        self.override_from_flags()
+        self.override_paths_from_flags()
         self.load_project_from_yaml()
         self.decide_object_creation()
+        self.override_object_creation_from_flags()
         logger.debug(f"Project name: {self.project_name}")
 
     def load_project_from_yaml(self):
@@ -103,11 +104,29 @@ class Project:
             is True
             else False
         )
+        logger.debug(yellow(f"Object creation dict:\n {self.object_creation_dct}"))
+        logger.debug(yellow(str(self.project_dict)))
 
-    def override_from_flags(self):
+    def override_paths_from_flags(self):
         if self.flags.project_dir:
             self.project_file_fullpath = Path(self.flags.project_dir, type(self).PROJECT_FILENAME)
+
         if self.flags.profile_dir:
             self.profile_dir = Path(self.flags.profile_dir)
+
         if self.flags.sheet_config_dir:
             self.sheet_config_dir = Path(self.flags.sheet_config_dir)
+
+    def override_object_creation_from_flags(self) -> None:
+        if self.flags.create_table:
+            logger.debug(yellow("going to create table"))
+            self.object_creation_dct.update({"create_table": True})
+
+        if self.flags.create_schema:
+            logger.debug(yellow("going to create schema"))
+            self.object_creation_dct.update({"create_schema": True})
+        logger.debug(yellow(f"Object creation dict after override\n {self.object_creation_dct}"))
+
+        if self.flags.destructive_create_table:
+            logger.debug(yellow("going to perform destuctive table creation"))
+            self.destructive_create_table = True

--- a/sheetwork/core/flags.py
+++ b/sheetwork/core/flags.py
@@ -19,7 +19,9 @@ class FlagParser:
         project_name: str = str(),
     ):
         self.sheet_name = test_sheet_name
-        self.create_table = False
+        self.create_table: bool = False
+        self.create_schema: bool = False
+        self.destructive_create_table: bool = False
         self.sheet_key = str()
         self.target_schema = str()
         self.target_table = str()
@@ -44,6 +46,8 @@ class FlagParser:
         if self.task == "upload":
             self.sheet_name = self.args.sheet_name
             self.create_table = self.args.create_table
+            self.create_schema = self.args.create_schema
+            self.destructive_create_table = self.args.destructive_create_table
             self.sheet_key = self.args.sheet_key
             self.target_schema = self.args.schema
             self.target_table = self.args.table

--- a/sheetwork/core/main.py
+++ b/sheetwork/core/main.py
@@ -82,6 +82,21 @@ upload_sub.add_argument(
     action="store_true",
     default=False,
 )
+upload_sub.add_argument(
+    "--create-schema",
+    help="When True schema will be created. If not called, the project argument `always_create_schema` may set it up.",
+    action="store_true",
+    default=False,
+)
+upload_sub.add_argument(
+    "--destructive-create-table",
+    help=(
+        "When true the target table will be replaced or droped. If not passed, the project"
+        "argument of the same name might override it"
+    ),
+    action="store_true",
+    default=False,
+)
 
 # Init task parser
 init_sub = subs.add_parser(

--- a/tests/project_test.py
+++ b/tests/project_test.py
@@ -41,9 +41,38 @@ def test_decide_object_creation(monkeypatch, datafiles, project_name):
     if project_name == "sheetwork_project_all_create":
         expected_object_creation_dict = {val: True for val in expected_object_creation_dict}
 
+    if project_name == "sheetwork_project_deprecated":
+        expected_object_creation_dict.update({"create_schema": False})
+
     flags = FlagParser(parser, project_dir=str(datafiles))
     project = Project(flags, project_name=project_name)
     project.decide_object_creation()
 
     assert project.object_creation_dct == expected_object_creation_dict
+    assert project.destructive_create_table is True
+
+
+@pytest.mark.parametrize(
+    "project_name",
+    ["sheetwork_project", "sheetwork_project_all_create", "sheetwork_project_deprecated"],
+)
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_override_object_creation_from_flags(monkeypatch, datafiles, project_name):
+    from sheetwork.core.flags import FlagParser
+    from sheetwork.core.config.profile import Project
+    from sheetwork.core.main import parser
+
+    def mock_consume_cli_arguments(self):
+        self.create_table = True
+        self.destructive_create_table = True
+
+    monkeypatch.setattr(FlagParser, "consume_cli_arguments", mock_consume_cli_arguments)
+    flags = FlagParser(parser, project_dir=str(datafiles))
+    flags.consume_cli_arguments()
+
+    project = Project(flags, project_name=project_name)
+    project.decide_object_creation()
+
+    assert project.object_creation_dct["create_table"] is True
+    assert project.object_creation_dct["create_schema"] is True
     assert project.destructive_create_table is True

--- a/tests/sheetwork_project.yml
+++ b/tests/sheetwork_project.yml
@@ -1,5 +1,5 @@
 name: "sheetwork_test"
 target_schema: "sand"
-always_create_table: true
 always_create_schema: true
+always_create_table: true
 destructive_create_table: true

--- a/tests/sheetwork_project_deprecated.yml
+++ b/tests/sheetwork_project_deprecated.yml
@@ -1,5 +1,4 @@
 name: "sheetwork_test"
 target_schema: "sand"
 always_create: true
-# always_create_schema: true
 destructive_create_table: true

--- a/tests/sheetwork_project_deprecated.yml
+++ b/tests/sheetwork_project_deprecated.yml
@@ -1,5 +1,5 @@
 name: "sheetwork_test"
 target_schema: "sand"
 always_create: true
-always_create_schema: true
+# always_create_schema: true
 destructive_create_table: true


### PR DESCRIPTION
## Description
In order to override (or set on demand) object creation (tables and schemas) we now provide the following CLI arguments:
- `create-table`
- `create-schema`
- `destructive-create-table`

These arguments are "companions" which can override the following project configuration arguments:
- `always_create_table`
- `always_create_schema`
- `destructive_create_table`

**IMPORTANT**:CLI flags will override whatever is already present in the project config

## How has this change been tested?

Tested locally with a bunch of different combination and override + a small `pytest` addition

## Supporting doc, tickets, issues

Closes #264

