### PR TITLE
refactor: :lipstick: implement better version checking

### DIFF
--- a/sheetwork/core/main.py
+++ b/sheetwork/core/main.py
@@ -1,5 +1,6 @@
 """Main module for sheetwork. Sets up Arguments to parse and task handling. That's it!"""
 import argparse
+import sys
 from typing import Union
 
 import sheetwork.core.sheetwork as upload_task
@@ -18,14 +19,31 @@ from sheetwork.core.utils import check_and_compare_version
 # to identify sheetwork code --we use this arg in `core.logger to shorten the traceback`
 __SHEETWORK_CODE = True
 
+
+def check_and_print_version() -> str:
+    """Calls check_and_compare_version and formats a message that works both for main and argparse.
+
+    Returns:
+        str: version info message ready for printing
+    """
+    needs_update, latest_version = check_and_compare_version()
+    installed_version_message = f"Installed Sheetwork version: {__version__}".rjust(40)
+    latest_version_message = f"Latest Sheetwork version: {latest_version}".rjust(40)
+    if latest_version:
+        return "\n".join([installed_version_message, latest_version_message])
+    return installed_version_message
+
+
+# general parser
 parser = argparse.ArgumentParser(
     prog="sheetwork",
     formatter_class=argparse.RawTextHelpFormatter,
     description="CLI tool to load google sheets onto a DB.",
     epilog="Select one of these sub-commands to find specific help for those.",
 )
-parser.add_argument("-v", "--version", action="version", version=f"%(prog)s Running v{__version__}")
+parser.add_argument("-v", "--version", action="version", version=check_and_print_version())
 
+# base sub parser
 base_subparser = argparse.ArgumentParser(add_help=False)
 base_subparser.add_argument("--log-level", help="sets the log level", type=str, default=str())
 base_subparser.add_argument(
@@ -152,8 +170,12 @@ def handle(parser: argparse.ArgumentParser) -> Union[InitTask, SheetBag, None]:
 
 def main(parser: argparse.ArgumentParser = parser):
     """Just your boring main."""
-    print(f"Sheetwork version: {__version__} \n")
-    check_and_compare_version()
+    # print version on every run unless doing `--version` which is better handled by argparse
+    if "--version" not in sys.argv:
+        version_message = check_and_print_version()
+        print(version_message)
+        print("\n")
+
     if parser:
         handle(parser)
     else:

--- a/sheetwork/core/utils.py
+++ b/sheetwork/core/utils.py
@@ -134,7 +134,7 @@ def check_dupe_cols(columns: List[str], suppress_warning: bool = False) -> Optio
     return dupes
 
 
-def check_and_compare_version(external_version: Optional[str] = str()) -> bool:
+def check_and_compare_version(external_version: Optional[str] = str()) -> Tuple[bool, str]:
     """Checks what the currently installed version of sheetwork is and compares it to the one on PyPI.
 
     This requires an internet connection. In the case where this doesn't happen a URLError will
@@ -160,10 +160,10 @@ def check_and_compare_version(external_version: Optional[str] = str()) -> bool:
                     f"Looks like you're a bit behind. A newer version of Sheetwork v{pypi_version} is available."
                 )
             )
-        return needs_update
+        return needs_update, pypi_version
 
     except URLError:
-        return False
+        return False, str()
 
 
 def cast_pandas_dtypes(df: pandas.DataFrame, overwrite_dict: dict = dict()) -> pandas.DataFrame:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -34,8 +34,9 @@ def test_check_and_compare_version(mocker):
     # mock the call to pypi
     mocker.patch("luddite.get_version_pypi", return_value="1.0.0")
     dummy_version = "0.0.0"
-    needs_update = check_and_compare_version(dummy_version)
+    needs_update, pypi_version = check_and_compare_version(dummy_version)
     assert needs_update is True
+    assert pypi_version == "1.0.0"
 
 
 def test_cast_pandas_dtypes():


### PR DESCRIPTION
## Description
When doing `sheetwork --version` we used to be getting the version information twice and the previous simple implementation of `argparse` wasn't able to check PyPI if there was a new release.

Now, the whole version logic lives in a method that always checks PyPI for new version. The function then takes care of generating a string to print directly which can be fed to both `argparse` or called in the `main.py` module.

## How has this change been tested?
Tests are updated + tested by doing `sheetwork --version` and `sheetwork upload --dry-run`

## Supporting doc, tickets, issues

Closes #268

