### PR TITLE
refactor: :lipstick: use pretty-errors for tracebacks

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = cerberus,colorama,gspread,inflection,luddite,mock,numpy,packaging,pandas,pytest,retrying,snowflake,sqlalchemy,yaml
+known_third_party = cerberus,colorama,gspread,inflection,luddite,mock,numpy,packaging,pandas,pretty_errors,pytest,retrying,snowflake,sqlalchemy,yaml

--- a/poetry.lock
+++ b/poetry.lock
@@ -547,6 +547,17 @@ importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 dev = ["pre-commit", "tox"]
 
 [[package]]
+name = "pretty-errors"
+version = "1.2.19"
+description = "Prettifies Python exception output to make it legible."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+colorama = "*"
+
+[[package]]
 name = "py"
 version = "1.9.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -967,7 +978,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "3988da513ff1230bab25b6ece110958c02a2e18fda49c0660f947c1905ea41c1"
+content-hash = "f0250a79c00db02686c753551a283f65a140d0cdf79761c9c69effeb4cc09021"
 
 [metadata.files]
 appdirs = [
@@ -1345,6 +1356,10 @@ pandas = [
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+pretty-errors = [
+    {file = "pretty_errors-1.2.19-py3-none-any.whl", hash = "sha256:87fd3071dbc302c9064f5b9a6114ea1678dda6ace70cbcd1452e46661af408e6"},
+    {file = "pretty_errors-1.2.19.tar.gz", hash = "sha256:b37b8a84634e9e6294273926e9cdea99414390e9a329293d018a1b4bbe8e2aa7"},
 ]
 py = [
     {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ colorama = "^0.4.3"
 luddite = "^1.0.1"
 packaging = "^20.4"
 retrying = "^1.3.3"
+pretty-errors = "^1.2.19"
 
 [tool.poetry.dev-dependencies]
 bumpversion = "^0.6.0"

--- a/sheetwork/core/main.py
+++ b/sheetwork/core/main.py
@@ -16,9 +16,6 @@ from sheetwork.core.task.init import InitTask
 from sheetwork.core.ui.traceback_manager import SheetworkTracebackManager
 from sheetwork.core.utils import check_and_compare_version
 
-# to identify sheetwork code --we use this arg in `core.logger to shorten the traceback`
-__SHEETWORK_CODE = True
-
 
 def check_and_print_version() -> str:
     """Calls check_and_compare_version and formats a message that works both for main and argparse.


### PR DESCRIPTION
## Description
Uses `pretty-errors` for pretty tracebacks

Closes #284 
