### PR TITLE
fix: :bug: handle bool casting explicitly

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -688,6 +688,17 @@ py = "*"
 pytest = ">=3.6"
 
 [[package]]
+name = "pytest-instafail"
+version = "0.4.2"
+description = "pytest plugin to show failures instantly"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+pytest = ">=2.9"
+
+[[package]]
 name = "pytest-mock"
 version = "3.3.1"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -700,6 +711,19 @@ pytest = ">=5.0"
 
 [package.extras]
 dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
+name = "pytest-sugar"
+version = "0.9.4"
+description = "pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+packaging = ">=14.1"
+pytest = ">=2.9"
+termcolor = ">=1.1.0"
 
 [[package]]
 name = "python-dateutil"
@@ -867,6 +891,14 @@ postgresql_psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql"]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+description = "ANSII Color formatting for output in terminal."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -978,7 +1010,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "f0250a79c00db02686c753551a283f65a140d0cdf79761c9c69effeb4cc09021"
+content-hash = "a023a56243f558f6b5f61b9813a65e1c43e4e14f208a3276aa624b877e786ef7"
 
 [metadata.files]
 appdirs = [
@@ -1460,9 +1492,16 @@ pytest-datafiles = [
     {file = "pytest-datafiles-2.0.tar.gz", hash = "sha256:143329cbb1dbbb07af24f88fa4668e2f59ce233696cf12c49fd1c98d1756dbf9"},
     {file = "pytest_datafiles-2.0-py2.py3-none-any.whl", hash = "sha256:e349b6ad7bcca111f3677b7201d3ca81f93b5e09dcfae8ee2be2c3cae9f55bc7"},
 ]
+pytest-instafail = [
+    {file = "pytest-instafail-0.4.2.tar.gz", hash = "sha256:19273fdf3f0f9a1cb4b7a0bc8aa1bdaaf6b0f62a681b693d5eca4626abc99782"},
+    {file = "pytest_instafail-0.4.2-py2.py3-none-any.whl", hash = "sha256:1ec440a177be89a9ed2759dade8e1f7a2b95bac74ae81dc91318d309bf4ebd4f"},
+]
 pytest-mock = [
     {file = "pytest-mock-3.3.1.tar.gz", hash = "sha256:a4d6d37329e4a893e77d9ffa89e838dd2b45d5dc099984cf03c703ac8411bb82"},
     {file = "pytest_mock-3.3.1-py3-none-any.whl", hash = "sha256:024e405ad382646318c4281948aadf6fe1135632bea9cc67366ea0c4098ef5f2"},
+]
+pytest-sugar = [
+    {file = "pytest-sugar-0.9.4.tar.gz", hash = "sha256:b1b2186b0a72aada6859bea2a5764145e3aaa2c1cfbb23c3a19b5f7b697563d3"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
@@ -1571,6 +1610,9 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.3.20-cp39-cp39-win32.whl", hash = "sha256:0cca1844ba870e81c03633a99aa3dc62256fb96323431a5dec7d4e503c26372d"},
     {file = "SQLAlchemy-1.3.20-cp39-cp39-win_amd64.whl", hash = "sha256:d05cef4a164b44ffda58200efcb22355350979e000828479971ebca49b82ddb1"},
     {file = "SQLAlchemy-1.3.20.tar.gz", hash = "sha256:d2f25c7f410338d31666d7ddedfa67570900e248b940d186b48461bd4e5569a1"},
+]
+termcolor = [
+    {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ pytest-mock = "^3.3.1"
 pytest-datafiles = "^2.0"
 towncrier = "^19.2.0"
 tox = "^3.20.1"
+pytest-sugar = "^0.9.4"
+pytest-instafail = "^0.4.2"
 
 [tool.poetry.extras]
 test = ["pytest"]

--- a/sheetwork/core/adapters/impl.py
+++ b/sheetwork/core/adapters/impl.py
@@ -51,7 +51,8 @@ class SnowflakeAdapter(BaseSQLAdapter):
     def _create_schema(self) -> None:
         if self._has_connection is False:
             raise NoAcquiredConnectionError(
-                f"No acquired connection for {type(self).__name__}. Make sure you call `acquire_connection` before."
+                f"No acquired connection for {type(self).__name__}. Make sure you call "
+                "`acquire_connection` before."
             )
         try:
             if self.config.project.object_creation_dct["create_schema"]:

--- a/sheetwork/core/exceptions.py
+++ b/sheetwork/core/exceptions.py
@@ -99,3 +99,7 @@ class InvalidOrMissingCommandError(SheetWorkError):
 
 class GoogleClientNotAuthenticatedError(SheetWorkError):
     """when you forgot to run authenticate or it failed."""
+
+
+class ColumnNotBooleanCompatibleError(SheetWorkError):
+    """when a column that is asked for being concerted to bool does not have compatible values"""

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -70,6 +70,8 @@ TO_CAST_DF = {
     "col_int": ["1", "2", "32"],
     "col_varchar": ["foo", "bar", "fizz"],
     "created_date": ["2019/01/01", "2019/01/02", "2019/01/03"],
+    "col_bool": ["false", "False", "true"],
+    "col_numeric": ["1.2", "1.3", "1"],
 }
 
 CAST_DF = {
@@ -81,6 +83,8 @@ CAST_DF = {
         1: Timestamp("2019-01-02 00:00:00"),
         2: Timestamp("2019-01-03 00:00:00"),
     },
+    "col_bool": {0: False, 1: False, 2: True},
+    "col_numeric": {0: 1.2, 1: 1.3, 2: 1},
 }
 
 CASING_DF = {

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -4,6 +4,8 @@ CASTING_DICT = {
     "col_int": "int",
     "col_varchar": "varchar",
     "created_date": "date",
+    "col_bool": "boolean",
+    "col_numeric": "numeric",
 }
 
 


### PR DESCRIPTION
- add pytest sugar and instafail to dev deps
- implement special handling for bool casting
- Add test for boolean and numeric

## Description
Somewhere between `v1.0.0` and up we introduced a bit of a bug/regression with pandas datatype casting prior to database expoure.

When using `df.astype('boolean')` on a string column (which is the way they come to us when read from the google sheet) does not lead to the intended behaviour that string `false` or `true` would get converted to `False` or `True` builtin booleans.
Rather what was happening was that if the string was not null the value that `.astype()` would create is `True` all the time.

Unfortunately boolean conversion was not being covered by the test we had on `cast_pandas_dtypes`. :facepalm:

A hot fix was merged in #289, which consisted in **ignoring** casting of boolean columns even if the user asked for it on the `sheet.yml` config.

This PR offers a much better solution and will actually **error** if the user request a column to be cast as boolean while it contains strings other than things that are mappable to booleans (i.e. string versions of false and true).

## How has this change been tested?
Implemented additional condition in `tests/utils_test.py`
Also testsed agains an actual sheet in the database.

## Supporting doc, tickets, issues
Closes #288

