### PR TITLE
refactor: raise all errors that might happen in loading

### DIFF
--- a/changelog/295.misc.rst
+++ b/changelog/295.misc.rst
@@ -1,1 +1,1 @@
-``make_df_from_worksheet()`` now throws more errors and wraps them into the a custom exception named ``SheetLoadingError``. The previous behaviour was causing too much silentness and prevented user from seeing errors such as the ones highlighted in #293
+``make_df_from_worksheet()`` now throws more errors and wraps them into the a custom exception named ``SheetLoadingError``. The previous behaviour was causing too much silentness and prevented user from seeing errors such as the ones highlighted in #292

--- a/changelog/295.misc.rst
+++ b/changelog/295.misc.rst
@@ -1,0 +1,1 @@
+``make_df_from_worksheet()`` now throws more errors and wraps them into the a custom exception named ``SheetLoadingError``. The previous behaviour was causing too much silentness and prevented user from seeing errors such as the ones highlighted in #293

--- a/sheetwork/core/clients/google.py
+++ b/sheetwork/core/clients/google.py
@@ -4,7 +4,7 @@ from typing import Any, List, Tuple
 
 import gspread
 import pandas
-from gspread.exceptions import SpreadsheetNotFound, WorksheetNotFound
+from gspread.exceptions import SpreadsheetNotFound
 
 from sheetwork.core.config.profile import Profile
 from sheetwork.core.exceptions import (
@@ -12,10 +12,10 @@ from sheetwork.core.exceptions import (
     GoogleCredentialsFileMissingError,
     GoogleSpreadSheetNotFound,
     NoWorkbookLoadedError,
-    WorksheetNotFoundError,
+    SheetLoadingError,
 )
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
-from sheetwork.core.ui.printer import green
+from sheetwork.core.ui.printer import green, yellow
 from sheetwork.core.utils import check_dupe_cols
 
 
@@ -155,9 +155,7 @@ class GoogleSpreadsheet:
                 df = pandas.DataFrame(values[1:], columns=values[0])
             else:
                 df = pandas.DataFrame(worksheet.get_all_values())
+            logger.debug(yellow(f"Raw obtained google sheet: \n {df.head()}"))
             return df
-        except WorksheetNotFound:
-            raise WorksheetNotFoundError(
-                f"Could not find {worksheet_name} in workbook. "
-                "If 'default sheet' not found all sheets in the workbook may be empty."
-            )
+        except Exception as e:
+            raise SheetLoadingError(f"Error loading sheet: \n {e}")

--- a/sheetwork/core/exceptions.py
+++ b/sheetwork/core/exceptions.py
@@ -25,8 +25,8 @@ class NoWorkbookLoadedError(SheetWorkError):
     """When the workbook object is None."""
 
 
-class WorksheetNotFoundError(SheetWorkError):
-    """when a referred worksheet cannot be found in the workbook."""
+class SheetLoadingError(SheetWorkError):
+    """When a referred an error happens during sheet loading."""
 
 
 class YAMLFileEmptyError(SheetWorkError):


### PR DESCRIPTION
## Description
`make_df_from_worksheet()` was a bit to error hungry and ate all loading errors unless they were of type `WorksheetNotFoundError`. This hid a few errors too many and now that we do retries it was potentially too silent.

## How has this change been tested?
Tested manually with a broken sheet.

## Supporting doc, tickets, issues
Was uncovered when trying to replicate #292 
