### PR TITLE
feat: throw EmptyHeaderError when header contains empty cols

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -1,6 +1,8 @@
 name: sheetwork build, test, cov report
 
-on: ["push", "pull_request_target"]
+on:
+  pull_request_target:
+    types: [assigned, opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -1,6 +1,6 @@
 name: sheetwork build, test, cov report
 
-on: "push"
+on: ["push", "pull_request_target"]
 
 jobs:
   build:

--- a/.github/workflows/tox_suite.yml
+++ b/.github/workflows/tox_suite.yml
@@ -1,6 +1,6 @@
 name: tox ci
 
-on: "push"
+on: ["push", "pull_request_target"]
 
 jobs:
   build:

--- a/sheetwork/core/exceptions.py
+++ b/sheetwork/core/exceptions.py
@@ -102,4 +102,8 @@ class GoogleClientNotAuthenticatedError(SheetWorkError):
 
 
 class ColumnNotBooleanCompatibleError(SheetWorkError):
-    """when a column that is asked for being concerted to bool does not have compatible values"""
+    """when a column that is asked for being concerted to bool does not have compatible values."""
+
+
+class EmptyHeaderError(SheetWorkError):
+    """when at least 1 column header is made of whitespaces only."""

--- a/sheetwork/core/sheetwork.py
+++ b/sheetwork/core/sheetwork.py
@@ -13,11 +13,10 @@ from sheetwork.core.cleaner import SheetCleaner
 from sheetwork.core.clients.google import GoogleSpreadsheet
 from sheetwork.core.config.config import ConfigLoader
 from sheetwork.core.config.profile import Profile
-from sheetwork.core.exceptions import EmptyHeaderError
 from sheetwork.core.flags import FlagParser
 from sheetwork.core.logger import GLOBAL_LOGGER as logger
 from sheetwork.core.ui.printer import red, timed_message, yellow
-from sheetwork.core.utils import check_columns_in_df
+from sheetwork.core.utils import assert_no_empty_header_cols, check_columns_in_df
 
 
 class SheetBag:
@@ -112,10 +111,7 @@ class SheetBag:
         logger.debug(f"Columns imported from sheet: {df.columns.tolist()}")
 
         # Check that headers are in the 1st row
-        if self.count_empty_header_cols_in_df(df) > 0:
-            raise EmptyHeaderError(
-                f"The google sheet contains {self.count_empty_header_cols_in_df(df)} column(s) with empty header."
-            )
+        _ = assert_no_empty_header_cols(df)
 
         # Perform exclusions, renamings and cleanups before releasing the sheet.
         df = self.exclude_columns(df)
@@ -124,20 +120,6 @@ class SheetBag:
         logger.debug(f"Columns after cleanups and exclusions: {df.columns}")
         logger.debug(f"Loaded SHEET HEAD: {df}")
         self.sheet_df = df
-
-    def count_empty_header_cols_in_df(self, df: pandas.DataFrame) -> int:
-        """Check how many headers are made of whitespaces only.
-
-        Later on, it will raise an issue for the user to provide proper naming in order to write in the database.
-
-        Args:
-            df (pandas.DataFrame): DataFrame downloaded from google sheet.
-
-        Returns:
-            int: number of columns with empty headers in df
-        """
-        cnt = (df.rename(columns=lambda x: x.strip()).columns == "").sum()
-        return cnt
 
     def rename_columns(self, df: pandas.DataFrame):
         if self.config.sheet_column_rename_dict:

--- a/sheetwork/core/sheetwork.py
+++ b/sheetwork/core/sheetwork.py
@@ -112,9 +112,9 @@ class SheetBag:
         logger.debug(f"Columns imported from sheet: {df.columns.tolist()}")
 
         # Check that headers are in the 1st row
-        if self.count_empty_headers(df) > 0:
+        if self.count_empty_header_cols_in_df(df) > 0:
             raise EmptyHeaderError(
-                f"The google sheet contains {self.count_empty_headers(df)} column(s) with empty header."
+                f"The google sheet contains {self.count_empty_header_cols_in_df(df)} column(s) with empty header."
             )
 
         # Perform exclusions, renamings and cleanups before releasing the sheet.
@@ -125,7 +125,7 @@ class SheetBag:
         logger.debug(f"Loaded SHEET HEAD: {df}")
         self.sheet_df = df
 
-    def count_empty_headers(self, df: pandas.DataFrame) -> int:
+    def count_empty_header_cols_in_df(self, df: pandas.DataFrame) -> int:
         """Check how many headers are made of whitespaces only.
 
         Later on, it will raise an issue for the user to provide proper naming in order to write in the database.

--- a/sheetwork/core/utils.py
+++ b/sheetwork/core/utils.py
@@ -14,6 +14,7 @@ from sheetwork.core.exceptions import (
     ColumnNotBooleanCompatibleError,
     ColumnNotFoundInDataFrame,
     DuplicatedColumnsInSheet,
+    EmptyHeaderError,
     NearestFileNotFound,
     UnsupportedDataTypeError,
 )
@@ -295,3 +296,20 @@ def deprecate(message: str, colour: str = "yellow") -> None:
             "ignore", ".*", category=DeprecationWarning, module="gspread_pandas"
         )
     warnings.warn(_message, DeprecationWarning, stacklevel=2)
+
+
+def assert_no_empty_header_cols(df: pandas.DataFrame) -> bool:
+    """Check that no header cols are made of whitespaces only.
+
+    Args:
+        df (pandas.DataFrame): DataFrame downloaded from google sheet.
+
+    Returns:
+        bool: True if at least 1 header column is empty
+    """
+    count_empty_header_columns = (df.rename(columns=lambda x: x.strip()).columns == "").sum()
+    if count_empty_header_columns > 0:
+        raise EmptyHeaderError(
+            f"The google sheet contains {count_empty_header_columns} column(s) with empty header."
+        )
+    return True

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -134,6 +134,15 @@ EMPTY_HEADER_COLUMNS_DF = {
     " col_1": [1, 2, 33],
 }
 
+NON_EMPTY_HEADER = {
+    "col_a": [1, 2, 32],
+    "col b": ["as .    ", "b", "   c"],
+    "1. col_one": ["aa", "bb", "cc"],
+    "col_1": [1, 2, 33],
+    "long ass name": ["foo", "bar", "fizz"],
+    "col_with_empty_string": ["1", "", "2"],
+}
+
 
 def generate_test_df(df):
     test_df = pandas.DataFrame.from_dict(df)

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -126,6 +126,14 @@ RENAMED_COLS = ["col_a", "col b", "1. col_one", "", "col_1", "renamed_col", "col
 
 EXCLUDED_DF_COLS = ["col_a", "col b", "1. col_one", "", "long ass name"]
 
+EMPTY_HEADER_COLUMNS_DF = {
+    "col_ a  ": [1, 2, 32],
+    "  ": ["as .    ", "b", "   c"],
+    "1. col_one": ["aa", "bb", "cc"],
+    "": ["q", "q", "q"],
+    " col_1": [1, 2, 33],
+}
+
 
 def generate_test_df(df):
     test_df = pandas.DataFrame.from_dict(df)

--- a/tests/sheetloader_test.py
+++ b/tests/sheetloader_test.py
@@ -2,6 +2,7 @@ import os
 
 import mock
 import pytest
+from pandas.testing import assert_frame_equal
 
 from sheetwork.core.config.config import ConfigLoader
 from sheetwork.core.config.profile import Profile
@@ -13,6 +14,7 @@ from tests.mockers import (
     EXCLUDED_DF_COLS,
     RENAMED_COLS,
     RENAMED_DF,
+    NON_EMPTY_HEADER,
     generate_test_df,
 )
 
@@ -77,9 +79,9 @@ def test_load_sheet(datafiles):
     config = ConfigLoader(flags, project)
     profile = Profile(project)
     with mock.patch.object(
-        SheetBag, "_obtain_googlesheet", return_value=generate_test_df(DIRTY_DF)
+        SheetBag, "_obtain_googlesheet", return_value=generate_test_df(NON_EMPTY_HEADER)
     ):
         sheetbag = SheetBag(config, flags, profile)
         sheetbag.load_sheet()
         target_df = generate_test_df(RENAMED_DF)
-        assert target_df.equals(sheetbag.sheet_df)
+        assert_frame_equal(target_df, sheetbag.sheet_df)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,4 +1,6 @@
-from .mockers import CAST_DF, TO_CAST_DF, generate_test_df
+import pytest
+
+from .mockers import CAST_DF, EMPTY_HEADER_COLUMNS_DF, TO_CAST_DF, generate_test_df
 
 CASTING_DICT = {
     "col_int": "int",
@@ -49,3 +51,12 @@ def test_cast_pandas_dtypes():
     expected_cast = generate_test_df(CAST_DF)
 
     assert cast_df.to_dict() == expected_cast.to_dict()
+
+
+def test_assert_no_empty_header_cols():
+    from sheetwork.core.utils import assert_no_empty_header_cols
+    from sheetwork.core.exceptions import EmptyHeaderError
+
+    test_df = generate_test_df(EMPTY_HEADER_COLUMNS_DF)
+    with pytest.raises(EmptyHeaderError):
+        assert_no_empty_header_cols(test_df)


### PR DESCRIPTION
## Description

This PR addresses the [issue 293](https://github.com/bastienboutonnet/sheetwork/issues/293). It will raise an error when at least 1 column header is empty.

## How has this change been tested?
Locally only with [DIRTY_DF](https://github.com/bastienboutonnet/sheetwork/blob/e0ebbd5ec7a586ecd94af6380c71ca5e378e03d7/tests/mockers.py#L59)