### PR TITLE
refactor(adaptors): use pydantic to validate Snowflake creds

### DIFF
--- a/sheetwork/core/adapters/base/connection.py
+++ b/sheetwork/core/adapters/base/connection.py
@@ -18,3 +18,17 @@ class BaseConnection(abc.ABC):  # noqa D101
     @abc.abstractmethod
     def generate_engine(self) -> None:
         raise NotImplementedError()
+
+
+def check_db_type_compatibility(field: str, expected_db: str) -> str:
+    """Pydantic validation decocator that checks that the a field has an expected value.
+
+    Args:
+        field (str): Value to check.
+        expected_db (str): Name of the expected database.
+
+    Returns:
+        str: the value of the field to check if validation is passed.
+    """
+    assert field == expected_db
+    return field

--- a/sheetwork/core/adapters/base/connection.py
+++ b/sheetwork/core/adapters/base/connection.py
@@ -6,12 +6,8 @@ class BaseCredentials(abc.ABC):
     """Base class to define basic API contract for a Credentials class and its methods."""
 
     @abc.abstractmethod
-    def validate_credentials(self) -> None:
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def parse_credentials(self) -> None:
-        raise NotImplementedError()
+    def parse_and_validate_credentials(self):
+        ...
 
 
 class BaseConnection(abc.ABC):  # noqa D101

--- a/sheetwork/core/adapters/postgres/connection.py
+++ b/sheetwork/core/adapters/postgres/connection.py
@@ -24,6 +24,11 @@ class PostgresCredentialsModel(BaseModel):
         check_db_type_compatibility
     )
 
+    class Config:
+        """Handles field remapping to avoid keyword collision."""
+
+        fields = {"target_schema": "schema"}
+
 
 class PostgresCredentials:
     """Parses and sets up Postgres credentials object."""

--- a/sheetwork/core/adapters/postgres/connection.py
+++ b/sheetwork/core/adapters/postgres/connection.py
@@ -72,16 +72,6 @@ class PostgresConnection(BaseConnection):
 
     def generate_engine(self) -> None:
         """Creates a Postgress connection engine."""
-        # engine_str = (
-        #     "postgresql+psycopg2://"
-        #     f"{self._credentials.user}"
-        #     f":{self._credentials.password}"
-        #     f"@{self._credentials.host}"
-        #     f"{':'+self._credentials.port if self._credentials.port else str()}"
-        #     f"{'/'+self._credentials.database if self._credentials.database else str()}"
-        # )
-        # self._engine_str = engine_str
-        # self.engine = create_engine(engine_str)
         self._engine_url = url.URL(
             drivername="postgresql+psycopg2",
             host=self._credentials.host,

--- a/sheetwork/core/adapters/postgres/connection.py
+++ b/sheetwork/core/adapters/postgres/connection.py
@@ -3,9 +3,9 @@
 from typing import Dict
 
 from pydantic import BaseModel, ValidationError, validator
-from sqlalchemy.engine import create_engine
+from sqlalchemy.engine import create_engine, url
 
-from sheetwork.core.adapters.base.connection import BaseConnection
+from sheetwork.core.adapters.base.connection import BaseConnection, check_db_type_compatibility
 from sheetwork.core.config.profile import Profile
 from sheetwork.core.exceptions import CredentialsParsingError
 
@@ -13,7 +13,6 @@ from sheetwork.core.exceptions import CredentialsParsingError
 class PostgresCredentialsModel(BaseModel):
     """Pydantic credentials validator model for postgres adaptor."""
 
-    db_type: str
     user: str
     password: str
     database: str
@@ -21,10 +20,9 @@ class PostgresCredentialsModel(BaseModel):
     port: str = "5432"
     target_schema: str
 
-    @validator("db_type")
-    def check_db_type_compatibility(cls, value):
-        assert value == "postgres"
-        return value
+    db_type = validator("db_type", "postgres", allow_reuse=True, check_fields=False)(
+        check_db_type_compatibility
+    )
 
 
 class PostgresCredentials:
@@ -56,12 +54,12 @@ class PostgresCredentials:
         self.credentials = _credentials.dict()
         self._db_type = self._profile.get("db_type", str())
         self.are_valid_credentials = True
-        self.user = self.credentials["user"]
-        self.password = self.credentials["password"]
-        self.host = self.credentials["host"]
-        self.port = self.credentials["port"]
-        self.database = self.credentials["database"]
-        self.target_schema = self.credentials["target_schema"]
+        self.user = self.credentials.get("user", str())
+        self.password = self.credentials.get("password", str())
+        self.host = self.credentials.get("host", str())
+        self.port = self.credentials.get("port", str())
+        self.database = self.credentials.get("database", str())
+        self.target_schema = self.credentials.get("target_schema", str())
 
 
 class PostgresConnection(BaseConnection):
@@ -74,13 +72,22 @@ class PostgresConnection(BaseConnection):
 
     def generate_engine(self) -> None:
         """Creates a Postgress connection engine."""
-        engine_str = (
-            "postgresql+psycopg2://"
-            f"{self._credentials.user}"
-            f":{self._credentials.password}"
-            f"@{self._credentials.host}"
-            f"{':'+self._credentials.port if self._credentials.port else str()}"
-            f"{'/'+self._credentials.database if self._credentials.database else str()}"
+        # engine_str = (
+        #     "postgresql+psycopg2://"
+        #     f"{self._credentials.user}"
+        #     f":{self._credentials.password}"
+        #     f"@{self._credentials.host}"
+        #     f"{':'+self._credentials.port if self._credentials.port else str()}"
+        #     f"{'/'+self._credentials.database if self._credentials.database else str()}"
+        # )
+        # self._engine_str = engine_str
+        # self.engine = create_engine(engine_str)
+        self._engine_url = url.URL(
+            drivername="postgresql+psycopg2",
+            host=self._credentials.host,
+            username=self._credentials.user,
+            password=self._credentials.password,
+            database=self._credentials.database,
+            port=self._credentials.port,
         )
-        self._engine_str = engine_str
-        self.engine = create_engine(engine_str)
+        self.engine = create_engine(self._engine_url)

--- a/sheetwork/core/adapters/snowflake/connection.py
+++ b/sheetwork/core/adapters/snowflake/connection.py
@@ -29,11 +29,6 @@ class SnowflakeCredentialsModel(BaseModel):
         check_db_type_compatibility
     )
 
-    # @validator("db_type", allow_reuse=True, check_fields=False)
-    # def check_db_type_compatibility(cls, value):
-    #     assert value == "snowflake"
-    #     return value
-
     class Config:
         """Handles field remapping to avoid keyword collision."""
 

--- a/sheetwork/core/adapters/snowflake/connection.py
+++ b/sheetwork/core/adapters/snowflake/connection.py
@@ -50,42 +50,6 @@ class SnowflakeCredentials(BaseCredentials):
         self.credentials: Dict[str, str] = dict()
         self.parse_and_validate_credentials()
 
-    def validate_credentials(self):
-        # check that all necessary keys are in the profile (nullity will have been handled by
-        # the yaml validator upsteam)
-        db_type = self.profile.get("db_type", str())
-        if db_type == "snowflake":
-            must_have_keys = {
-                "account",
-                "user",
-                "password",
-                "role",
-                "database",
-                "warehouse",
-                "target_schema",
-            }
-            keys_missing = must_have_keys.difference(self.profile.keys())
-            if keys_missing:
-                raise CredentialsParsingError(
-                    f"The following keys: {keys_missing} must be in your profile."
-                )
-            self.are_valid_credentials = True
-            self.db_type = db_type
-
-    def parse_credentials(self):
-        if self.profile.get("db_type") == "snowflake":
-            must_have_keys = {
-                "account",
-                "user",
-                "password",
-                "role",
-                "database",
-                "warehouse",
-                "target_schema",
-            }
-            for key in must_have_keys:
-                self.credentials.update({key: self.profile.get(key, str())})
-
     def parse_and_validate_credentials(self) -> None:
         """Parse and validate credentials using pydandic model.
 

--- a/sheetwork/core/adapters/snowflake/connection.py
+++ b/sheetwork/core/adapters/snowflake/connection.py
@@ -1,31 +1,43 @@
 """Concrete Snowflake Database Connection classes."""
 from typing import Dict
 
+from pydantic import BaseModel, ValidationError, validator
 from snowflake.sqlalchemy import URL
 from sqlalchemy import create_engine
 
-from sheetwork.core.adapters.base.connection import BaseConnection, BaseCredentials
+from sheetwork.core.adapters.base.connection import (
+    BaseConnection,
+    BaseCredentials,
+    check_db_type_compatibility,
+)
 from sheetwork.core.config.profile import Profile
 from sheetwork.core.exceptions import CredentialsParsingError
 
-# from pydantic import BaseModel, validator
 
+class SnowflakeCredentialsModel(BaseModel):
+    """Pydantic credentials validator model for Snowflake adaptor."""
 
-# class SnowflakeCredentialsModel(BaseModel):
-#     """Pydantic credentials validator model for Snowflake adaptor."""
+    account: str
+    user: str
+    password: str
+    role: str
+    database: str
+    warehouse: str
+    target_schema: str
 
-#     account: str
-#     user: str
-#     password: str
-#     role: str
-#     database: str
-#     warehouse: str
-#     target_schema: str
+    db_type = validator("db_type", "snowflake", allow_reuse=True, check_fields=False)(
+        check_db_type_compatibility
+    )
 
-#     @validator("db_type")
-#     def check_db_type_compatibility(cls, value):
-#         assert value == "snowflake"
-#         return value
+    # @validator("db_type", allow_reuse=True, check_fields=False)
+    # def check_db_type_compatibility(cls, value):
+    #     assert value == "snowflake"
+    #     return value
+
+    class Config:
+        """Handles field remapping to avoid keyword collision."""
+
+        fields = {"target_schema": "schema"}
 
 
 class SnowflakeCredentials(BaseCredentials):
@@ -41,8 +53,7 @@ class SnowflakeCredentials(BaseCredentials):
         self.are_valid_credentials: bool = False
         self.db_type: str = str()
         self.credentials: Dict[str, str] = dict()
-        self.validate_credentials()
-        self.parse_credentials()
+        self.parse_and_validate_credentials()
 
     def validate_credentials(self):
         # check that all necessary keys are in the profile (nullity will have been handled by
@@ -80,14 +91,26 @@ class SnowflakeCredentials(BaseCredentials):
             for key in must_have_keys:
                 self.credentials.update({key: self.profile.get(key, str())})
 
-    # def parse_and_validate_credentials(self) -> None:
-    #     """Parses profile.yml to obtain snowflake credientials and passes it throught pydantic."""
+    def parse_and_validate_credentials(self) -> None:
+        """Parse and validate credentials using pydandic model.
 
-    #     try:
-    #         _credentials = SnowflakeCredentialsModel(**self.profile)
-    #     except ValidationError as e:
-    #         raise CredentialsParsingError(f"Your profile is not valid \n {e}")
-    #     self.credentials = _credentials.dict()
+        Pydantic is called first to raise a ValidationError first and cause the app to crash.
+        """
+        try:
+            _credentials = SnowflakeCredentialsModel(**self.profile)
+        except ValidationError as e:
+            raise CredentialsParsingError(f"Your profile is not valid \n {e}")
+
+        self.credentials = _credentials.dict()
+        self.are_valid_credentials = True
+        self.db_type = self.profile.get("db_type", str())
+        self.user = self.credentials["user"]
+        self.password = self.credentials["password"]
+        self.account = self.credentials["account"]
+        self.role = self.credentials["role"]
+        self.warehouse = self.credentials["warehouse"]
+        self.database = self.credentials["database"]
+        self.target_schema = self.credentials["target_schema"]
 
 
 class SnowflakeConnection(BaseConnection):
@@ -107,12 +130,12 @@ class SnowflakeConnection(BaseConnection):
     def generate_engine(self):
         self.engine = create_engine(
             URL(
-                account=self.credentials.credentials.get("account"),
-                user=self.credentials.credentials.get("user"),
-                password=self.credentials.credentials.get("password"),
-                role=self.credentials.credentials.get("role"),
-                warehouse=self.credentials.credentials.get("warehouse"),
-                database=self.credentials.credentials.get("database"),
-                schema=self.credentials.credentials.get("target_schema"),
+                account=self.credentials.account,
+                user=self.credentials.user,
+                password=self.credentials.password,
+                role=self.credentials.role,
+                warehouse=self.credentials.warehouse,
+                database=self.credentials.database,
+                schema=self.credentials.target_schema,
             )
         )

--- a/sheetwork/core/config/profile.py
+++ b/sheetwork/core/config/profile.py
@@ -43,6 +43,7 @@ class Profile:
     def read_profile(self):
         logger.debug(f"Profile Name: {self.profile_name}")
         filename = Path(self.profile_dir, "profiles.yml")
+        target_profile = dict()
         if filename.exists():
             yaml_dict = open_yaml(filename)
             is_valid_yaml = validate_yaml(yaml_dict, profiles_schema)
@@ -56,7 +57,7 @@ class Profile:
                 if target_profile and is_valid_yaml:
                     is_valid_profile = self._validate_profile(target_profile)
                     if is_valid_profile:
-                        self.profile_dict = self._remap_profile_fields(target_profile)
+                        self.profile_dict = target_profile
                 else:
                     raise ProfileParserError(
                         f"Error finding and entry for target: {self.target_name}, "

--- a/tests/base_connection_test.py
+++ b/tests/base_connection_test.py
@@ -1,0 +1,5 @@
+def test_check_db_type_compatibility():
+    from sheetwork.core.adapters.base.connection import check_db_type_compatibility
+
+    field_value = check_db_type_compatibility("a", "a")
+    assert field_value == "a"

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -23,7 +23,7 @@ EXPECTED_DEV_TEST_PROFILE = {
     "role": "d",
     "database": "e",
     "warehouse": "f",
-    "target_schema": "g",
+    "schema": "g",
     "guser": "sheetwork_test@blahh.iam.gserviceaccount.com",
 }
 

--- a/tests/postgres_adaptor_test.py
+++ b/tests/postgres_adaptor_test.py
@@ -51,6 +51,7 @@ def test_generate_engine(datafiles):
     from sheetwork.core.main import parser
     from sheetwork.core.adapters.postgres.connection import PostgresCredentials
     from sheetwork.core.adapters.postgres.connection import PostgresConnection
+    from sqlalchemy.engine import url
 
     flags = FlagParser(parser, profile_dir=str(datafiles), project_dir=str(datafiles))
     project = Project(flags)
@@ -61,11 +62,16 @@ def test_generate_engine(datafiles):
 
     connection = PostgresConnection(credentials)
 
-    assert isinstance(connection.engine, sqlalchemy.engine.Engine)
-    assert (
-        connection._engine_str
-        == "postgresql+psycopg2://sheetwork_user:magical_password@localhost:5432/sheetwork_test"
+    expected_engine_url = url.URL(
+        drivername="postgresql+psycopg2",
+        host="localhost",
+        username="sheetwork_user",
+        password="magical_password",
+        database="sheetwork_test",
+        port="5432",
     )
+    assert isinstance(connection.engine, sqlalchemy.engine.Engine)
+    assert connection._engine_url == expected_engine_url
 
 
 @pytest.mark.parametrize("is_valid_table", [True, False])


### PR DESCRIPTION
## Description
When we added the Postgres adaptor we made a choice to use `pydantic` to validate the databsde credentials.

Since this simplifies and unifies the code quite a bit this PR ports the same logic into the Snowflake adaptor.


## How has this change been tested?
Unit tests should be a good coverage for this

