### PR TITLE
fix: make `--version` work again and :broom: some rogue prints

### DIFF
--- a/sheetwork/core/config/config.py
+++ b/sheetwork/core/config/config.py
@@ -102,7 +102,6 @@ class ConfigLoader:
     def get_sheet_config(self):
         if self.flags.sheet_name:
             sheets = self.config["sheets"]
-            print(f"KJSKDJHSDKJH {self.flags.sheet_name}")
             sheet_config = [
                 sheet for sheet in sheets if sheet.get("sheet_name") == self.flags.sheet_name
             ]

--- a/sheetwork/core/main.py
+++ b/sheetwork/core/main.py
@@ -182,5 +182,5 @@ def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = li
         print(version_message)
         print("\n")
 
-        handle(parser, _cli_args)
+    handle(parser, _cli_args)
     return 0

--- a/sheetwork/core/yaml/yaml_helpers.py
+++ b/sheetwork/core/yaml/yaml_helpers.py
@@ -38,5 +38,5 @@ def validate_yaml(yaml: Dict[Any, Any], validation_schema: Dict[Any, Any]) -> bo
     v = Validator()
     is_valid_yaml: bool = v.validate(yaml, validation_schema)  # type: ignore
     if not is_valid_yaml:
-        raise SheetConfigParsingError(f"scheet.yml is not formatted properly. \n {v.errors}")  # type: ignore
+        raise SheetConfigParsingError(f"sheet.yml is not formatted properly. \n {v.errors}")  # type: ignore
     return is_valid_yaml

--- a/tests/google_test.py
+++ b/tests/google_test.py
@@ -106,7 +106,6 @@ def test__check_google_creds_exits(datafiles, simulate_missing_creds):
     from sheetwork.core.clients.google import GoogleSpreadsheet
     from sheetwork.core.exceptions import GoogleCredentialsFileMissingError
 
-    print(str(datafiles))
     flags = FlagParser(parser, profile_dir=str(datafiles), project_dir=str(datafiles))
     project = Project(flags)
     profile = Profile(project, "dev")

--- a/tests/profile_test.py
+++ b/tests/profile_test.py
@@ -26,8 +26,6 @@ def test_read_profile(datafiles, target_name, profile_name, profile_dir):
 
     flags = FlagParser(parser, project_dir=str(datafiles), profile_dir=str(datafiles))
     project = Project(flags)
-    print(f"TARGET_NAME {target_name}")
-    print(f"PROFILE_NAME {profile_name}")
     if target_name == "non_existant" and profile_name == "sheetwork_test":
         with pytest.raises(ProfileParserError):
             profile = Profile(project, target_name)


### PR DESCRIPTION
## Description
- `--version` was broken because of an indentation caveat. This is fixed now
- some rogue prints from testing are also removed. Gosh `1.0.4` was a garbage release!
## How has this change been tested?

## Supporting doc, tickets, issues
Closes #310 