### PR TITLE
ci: change to pull_request trigger to prevent pwn

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -1,6 +1,6 @@
 name: sheetwork build, test, cov report
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -35,19 +35,20 @@ jobs:
         run: |
           PYTHONPATH=src/ poetry run python -m pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing  --cov=sheetwork tests/
 
-      - name: Upload coverage report to CodeCov for PRs
-        if: startsWith(github.event_name, 'pull_request_target')
-        env:
-          PR_NUM: ${{ github.event.pull_request.number }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: |
-          bash <(curl -s https://codecov.io/bash) -f coverage-reports/coverage.xml -Z -P $PR_NUM
-          exit $?
+      # - name: Upload coverage report to CodeCov for PRs
+      #   if: startsWith(github.event_name, 'pull_request_target')
+      #   env:
+      #     PR_NUM: ${{ github.event.pull_request.number }}
+      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      #   run: |
+      #     bash <(curl -s https://codecov.io/bash) -f coverage-reports/coverage.xml -Z -P $PR_NUM
+      #     exit $?
 
       - name: Upload coverage report to CodeCov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: GITHUB_RUN_ID
           file: coverage-reports/coverage.xml
           flags: unittests
           name: codecov-umbrella


### PR DESCRIPTION
## Description
`pull_request_target` exposes tokens: https://securitylab.github.com/research/github-actions-preventing-pwn-requests and https://www.youtube.com/watch?v=_fpXyS_i1xE

I had turned on this trigger to allow for forks to also be able to publish code coverage to codecov however they now (well for a while) provide tokenless report sending so this should be good.
